### PR TITLE
Support selected teacher materials in AI tools

### DIFF
--- a/material_source_helper.php
+++ b/material_source_helper.php
@@ -1,0 +1,281 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+
+defined('MOODLE_INTERNAL') || die();
+
+function local_aiskillnavigator_material_source_from_request(): array {
+    $sourcemode = optional_param('sourcemode', '', PARAM_ALPHA);
+    $materialids = optional_param_array('materialids', [], PARAM_INT);
+
+    // Backward compatibility with old URLs using materialid.
+    $oldmaterialid = optional_param('materialid', -999999, PARAM_INT);
+
+    if ($sourcemode === '' && empty($materialids) && $oldmaterialid !== -999999) {
+        if ($oldmaterialid === -1) {
+            $sourcemode = 'manual';
+        } else if ($oldmaterialid === 0) {
+            $sourcemode = 'all';
+        } else if ($oldmaterialid > 0) {
+            $sourcemode = 'selected';
+            $materialids = [$oldmaterialid];
+        }
+    }
+
+    if (!in_array($sourcemode, ['manual', 'all', 'selected'], true)) {
+        $sourcemode = 'manual';
+    }
+
+    $materialids = array_values(array_unique(array_filter(array_map('intval', $materialids), function ($id) {
+        return $id > 0;
+    })));
+
+    return [
+        'sourcemode' => $sourcemode,
+        'materialids' => $materialids,
+    ];
+}
+
+function local_aiskillnavigator_material_source_short_title(stdClass $material): string {
+    $title = trim((string) ($material->title ?? 'Materiale senza titolo'));
+
+    if ($title === '') {
+        $title = 'Materiale senza titolo';
+    }
+
+    $contentlength = strlen((string) ($material->content ?? ''));
+
+    return $title . ' (' . $contentlength . ' chars)';
+}
+
+function local_aiskillnavigator_material_source_get_readable_materials(int $courseid): array {
+    global $DB;
+
+    $materials = $DB->get_records(
+        'local_aiskillnav_material',
+        ['courseid' => $courseid],
+        'timecreated DESC'
+    );
+
+    $readablematerials = [];
+
+    foreach ($materials as $material) {
+        $content = trim((string) ($material->content ?? ''));
+
+        if ($content !== '') {
+            $readablematerials[(int) $material->id] = $material;
+        }
+    }
+
+    return $readablematerials;
+}
+
+function local_aiskillnavigator_material_source_select_materials(array $readablematerials, string $sourcemode, array $materialids): array {
+    if ($sourcemode === 'manual') {
+        return [];
+    }
+
+    if ($sourcemode === 'all') {
+        return array_values($readablematerials);
+    }
+
+    $selected = [];
+
+    foreach ($materialids as $materialid) {
+        if (isset($readablematerials[$materialid])) {
+            $selected[(int) $materialid] = $readablematerials[$materialid];
+        }
+    }
+
+    return array_values($selected);
+}
+
+function local_aiskillnavigator_material_source_count_chunks(
+    \local_aiskillnavigator\service\embedding_service $embeddingservice,
+    int $courseid,
+    string $sourcemode,
+    array $materialids
+): int {
+    if ($sourcemode === 'manual') {
+        return 0;
+    }
+
+    if ($sourcemode === 'all') {
+        return $embeddingservice->count_indexed_chunks($courseid);
+    }
+
+    $total = 0;
+
+    foreach ($materialids as $materialid) {
+        $total += $embeddingservice->count_indexed_chunks($courseid, (int) $materialid);
+    }
+
+    return $total;
+}
+
+function local_aiskillnavigator_material_source_search_rag(
+    \local_aiskillnavigator\service\embedding_service $embeddingservice,
+    string $query,
+    int $courseid,
+    string $sourcemode,
+    array $materialids,
+    int $topk
+): array {
+    if ($sourcemode === 'manual') {
+        return [];
+    }
+
+    if ($sourcemode === 'all') {
+        return $embeddingservice->search($query, $courseid, $topk, 0);
+    }
+
+    $merged = [];
+
+    foreach ($materialids as $materialid) {
+        $results = $embeddingservice->search($query, $courseid, $topk, (int) $materialid);
+
+        foreach ($results as $result) {
+            $key = (int) ($result->id ?? 0);
+
+            if ($key <= 0) {
+                $key = crc32(($result->title ?? '') . ($result->chunkindex ?? '') . ($result->chunktext ?? ''));
+            }
+
+            $merged[$key] = $result;
+        }
+    }
+
+    $merged = array_values($merged);
+
+    usort($merged, function ($a, $b) {
+        return ((float) ($b->similarity ?? 0)) <=> ((float) ($a->similarity ?? 0));
+    });
+
+    return array_slice($merged, 0, $topk);
+}
+
+function local_aiskillnavigator_material_source_render_controls(
+    array $readablematerials,
+    \local_aiskillnavigator\service\embedding_service $embeddingservice,
+    int $courseid,
+    string $sourcemode,
+    array $materialids,
+    string $label,
+    string $manualtext,
+    string $alltext,
+    string $selectedtext,
+    string $helptext
+): string {
+    $html = '';
+
+    $html .= html_writer::start_div('form-group');
+    $html .= html_writer::tag('label', $label, ['for' => 'sourcemode']);
+
+    $html .= html_writer::select(
+        [
+            'manual' => $manualtext,
+            'all' => $alltext,
+            'selected' => $selectedtext,
+        ],
+        'sourcemode',
+        $sourcemode,
+        false,
+        [
+            'class' => 'form-control',
+            'id' => 'sourcemode',
+        ]
+    );
+
+    $html .= html_writer::tag('small', $helptext, ['class' => 'form-text text-muted']);
+    $html .= html_writer::end_div();
+
+    $html .= html_writer::start_div('form-group mt-3', ['id' => 'selectedMaterialsBlock']);
+    $html .= html_writer::tag('label', 'Selected teacher materials', ['for' => 'materialids']);
+
+    $materialoptions = [];
+
+    foreach ($readablematerials as $material) {
+        $chunks = $embeddingservice->count_indexed_chunks($courseid, (int) $material->id);
+        $materialoptions[(int) $material->id] =
+            local_aiskillnavigator_material_source_short_title($material) . ' - RAG chunks: ' . $chunks;
+    }
+
+    if (empty($materialoptions)) {
+        $html .= html_writer::div('No readable teacher materials available yet.', 'alert alert-info mb-0');
+    } else {
+        $html .= html_writer::select(
+            $materialoptions,
+            'materialids[]',
+            $materialids,
+            false,
+            [
+                'class' => 'form-control',
+                'id' => 'materialids',
+                'multiple' => 'multiple',
+                'size' => min(8, max(3, count($materialoptions))),
+            ]
+        );
+
+        $html .= html_writer::tag(
+            'small',
+            'Hold CTRL to select multiple specific materials.',
+            ['class' => 'form-text text-muted']
+        );
+    }
+
+    $html .= html_writer::end_div();
+
+    return $html;
+}
+
+function local_aiskillnavigator_material_source_hidden_fields(string $sourcemode, array $materialids): string {
+    $html = '';
+
+    $html .= html_writer::empty_tag('input', [
+        'type' => 'hidden',
+        'name' => 'sourcemode',
+        'value' => $sourcemode,
+    ]);
+
+    foreach ($materialids as $materialid) {
+        $html .= html_writer::empty_tag('input', [
+            'type' => 'hidden',
+            'name' => 'materialids[]',
+            'value' => (int) $materialid,
+        ]);
+    }
+
+    return $html;
+}
+
+function local_aiskillnavigator_material_source_footer_script(): string {
+    return html_writer::tag('style', '
+#selectedMaterialsBlock.is-hidden {
+    display: none;
+}
+') . html_writer::tag('script', '
+(function () {
+    function updateMaterialSelectionVisibility() {
+        var sourceMode = document.getElementById("sourcemode");
+        var block = document.getElementById("selectedMaterialsBlock");
+
+        if (!sourceMode || !block) {
+            return;
+        }
+
+        if (sourceMode.value === "selected") {
+            block.classList.remove("is-hidden");
+        } else {
+            block.classList.add("is-hidden");
+        }
+    }
+
+    var sourceMode = document.getElementById("sourcemode");
+
+    if (sourceMode) {
+        sourceMode.addEventListener("change", updateMaterialSelectionVisibility);
+    }
+
+    updateMaterialSelectionVisibility();
+})();
+');
+}

--- a/mindmapgenerator.php
+++ b/mindmapgenerator.php
@@ -2,6 +2,7 @@
 // This file is part of Moodle - https://moodle.org/
 
 require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/material_source_helper.php');
 
 use local_aiskillnavigator\service\embedding_service;
 use local_aiskillnavigator\service\real_ai_service;
@@ -57,6 +58,15 @@ foreach ($materials as $material) {
 
 $embeddingservice = new embedding_service();
 $totalchunks = $embeddingservice->count_indexed_chunks($courseid);
+
+$sourcemode = local_aiskillnavigator_material_source_mode_from_request(-1);
+$selectedmaterialids = local_aiskillnavigator_material_source_selected_ids_from_request($readablematerials);
+$selectedmaterials = local_aiskillnavigator_material_source_selected_materials($readablematerials, $sourcemode, $selectedmaterialids);
+$materialid = local_aiskillnavigator_material_source_legacy_materialid($sourcemode, $selectedmaterialids);
+
+if ($sourcemode === 'selected' && empty($selectedmaterialids)) {
+    $warning = 'Select at least one teacher material or switch to all course materials.';
+}
 
 function local_aiskillnavigator_clean_ai_json_response(string $raw): string {
     $clean = trim($raw);
@@ -270,23 +280,16 @@ function local_aiskillnavigator_material_short_title(stdClass $material): string
 }
 
 if ($generate) {
-    if ($materialid === -1) {
-        $selectedmaterials = [];
-    } else if ($materialid > 0 && isset($readablematerials[$materialid])) {
-        $selectedmaterials = [$readablematerials[$materialid]];
-    } else {
-        $selectedmaterials = array_values($readablematerials);
-    }
+    $selectedmaterials = local_aiskillnavigator_material_source_selected_materials($readablematerials, $sourcemode, $selectedmaterialids);
 
     $service = new real_ai_service();
 
-    if ($materialid === -1) {
+    if ($sourcemode === 'manual') {
         $fallbacktopic = $topic !== '' ? $topic : 'Digital Twin';
         $result = $service->generate_mindmap($fallbacktopic);
     } else if ($totalchunks > 0) {
         $searchquery = $topic !== '' ? $topic : 'concept map based on course materials';
-        $searchmaterialid = $materialid > 0 ? $materialid : 0;
-        $results = $embeddingservice->search($searchquery, $courseid, 6, $searchmaterialid);
+        $results = local_aiskillnavigator_material_source_search($embeddingservice, $searchquery, $courseid, 6, $sourcemode, $selectedmaterialids);
 
         if (!empty($results)) {
             $ragcontext = $embeddingservice->build_context($results, 6500);
@@ -314,10 +317,9 @@ if ($generate) {
     $mindmap = local_aiskillnavigator_extract_json($result);
 
     if ($mindmap === null) {
-        if ($materialid !== -1 && $totalchunks > 0) {
+        if ($sourcemode !== 'manual' && $totalchunks > 0) {
             $searchquery = $topic !== '' ? $topic : 'concept map based on course materials';
-            $searchmaterialid = $materialid > 0 ? $materialid : 0;
-            $results = $embeddingservice->search($searchquery, $courseid, 6, $searchmaterialid);
+        $results = local_aiskillnavigator_material_source_search($embeddingservice, $searchquery, $courseid, 6, $sourcemode, $selectedmaterialids);
             $ragcontext = $embeddingservice->build_context($results, 6500);
             $result = $service->generate_mindmap_with_rag_context($topic, $ragcontext);
         } else {
@@ -396,36 +398,15 @@ echo html_writer::empty_tag('input', [
 ]);
 
 echo html_writer::start_div('form-group');
-
-echo html_writer::tag('label', 'Generation source', ['for' => 'materialid']);
-
-$materialoptions = [
-    -1 => 'Manual topic only (do not use teacher materials)',
-    0 => 'RAG semantic search (all course materials)',
-];
-
-foreach ($readablematerials as $material) {
-    $chunks = $embeddingservice->count_indexed_chunks($courseid, (int) $material->id);
-    $materialoptions[(int) $material->id] = local_aiskillnavigator_material_short_title($material) . ' — RAG chunks: ' . $chunks;
-}
-
-echo html_writer::select(
-    $materialoptions,
-    'materialid',
-    $materialid,
-    false,
-    [
-        'class' => 'form-control',
-        'id' => 'materialid',
-    ]
+echo local_aiskillnavigator_material_source_selector_html(
+    $readablematerials,
+    $embeddingservice,
+    $courseid,
+    $sourcemode,
+    $selectedmaterialids,
+    'Generation source',
+    'Choose Manual topic only for a generic map, all materials for full RAG search, or selected materials to build the mind map only from specific uploaded files.'
 );
-
-echo html_writer::tag(
-    'small',
-    'Choose Manual topic only for any generic topic, or choose RAG mode when you want the mind map grounded on indexed teacher materials.',
-    ['class' => 'form-text text-muted']
-);
-
 echo html_writer::end_div();
 
 echo html_writer::start_div('form-group mt-3');

--- a/quizgenerator.php
+++ b/quizgenerator.php
@@ -2,6 +2,7 @@
 // This file is part of Moodle - https://moodle.org/
 
 require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/material_source_helper.php');
 
 use local_aiskillnavigator\service\embedding_service;
 use local_aiskillnavigator\service\real_ai_service;
@@ -63,6 +64,15 @@ foreach ($materials as $material) {
 
 $embeddingservice = new embedding_service();
 $totalchunks = $embeddingservice->count_indexed_chunks($courseid);
+
+$sourcemode = local_aiskillnavigator_material_source_mode_from_request(-1);
+$selectedmaterialids = local_aiskillnavigator_material_source_selected_ids_from_request($readablematerials);
+$selectedmaterials = local_aiskillnavigator_material_source_selected_materials($readablematerials, $sourcemode, $selectedmaterialids);
+$materialid = local_aiskillnavigator_material_source_legacy_materialid($sourcemode, $selectedmaterialids);
+
+if ($sourcemode === 'selected' && empty($selectedmaterialids)) {
+    $warning = 'Select at least one teacher material or switch to all course materials.';
+}
 
 function local_aiskillnavigator_clean_ai_json_response(string $raw): string {
     $clean = trim($raw);
@@ -288,23 +298,16 @@ if ($action === 'grade') {
         $savedmessage = 'Quiz attempt saved in the student profile.';
     }
 } else if ($generate) {
-    if ($materialid === -1) {
-        $selectedmaterials = [];
-    } else if ($materialid > 0 && isset($readablematerials[$materialid])) {
-        $selectedmaterials = [$readablematerials[$materialid]];
-    } else {
-        $selectedmaterials = array_values($readablematerials);
-    }
+    $selectedmaterials = local_aiskillnavigator_material_source_selected_materials($readablematerials, $sourcemode, $selectedmaterialids);
 
     $service = new real_ai_service();
 
-    if ($materialid === -1) {
+    if ($sourcemode === 'manual') {
         $fallbacktopic = $topic !== '' ? $topic : 'Digital Twin';
         $result = $service->generate_quiz($fallbacktopic, $difficulty);
     } else if ($totalchunks > 0) {
         $searchquery = $topic !== '' ? $topic : 'quiz based on course materials';
-        $searchmaterialid = $materialid > 0 ? $materialid : 0;
-        $results = $embeddingservice->search($searchquery, $courseid, 6, $searchmaterialid);
+        $results = local_aiskillnavigator_material_source_search($embeddingservice, $searchquery, $courseid, 6, $sourcemode, $selectedmaterialids);
 
         if (!empty($results)) {
             $ragcontext = $embeddingservice->build_context($results, 6500);
@@ -332,10 +335,9 @@ if ($action === 'grade') {
     $quiz = local_aiskillnavigator_extract_quiz_json($result);
 
     if ($quiz === null) {
-        if ($materialid !== -1 && $totalchunks > 0) {
+        if ($sourcemode !== 'manual' && $totalchunks > 0) {
             $searchquery = $topic !== '' ? $topic : 'quiz based on course materials';
-            $searchmaterialid = $materialid > 0 ? $materialid : 0;
-            $results = $embeddingservice->search($searchquery, $courseid, 6, $searchmaterialid);
+        $results = local_aiskillnavigator_material_source_search($embeddingservice, $searchquery, $courseid, 6, $sourcemode, $selectedmaterialids);
             $ragcontext = $embeddingservice->build_context($results, 6500);
             $result = $service->generate_quiz_with_rag_context($topic, $difficulty, $ragcontext);
         } else {
@@ -418,36 +420,15 @@ echo html_writer::empty_tag('input', [
 ]);
 
 echo html_writer::start_div('form-group');
-
-echo html_writer::tag('label', 'Generation source', ['for' => 'materialid']);
-
-$materialoptions = [
-    -1 => 'Manual topic only (do not use teacher materials)',
-    0 => 'RAG semantic search (all course materials)',
-];
-
-foreach ($readablematerials as $material) {
-    $chunks = $embeddingservice->count_indexed_chunks($courseid, (int) $material->id);
-    $materialoptions[(int) $material->id] = local_aiskillnavigator_material_short_title($material) . ' — RAG chunks: ' . $chunks;
-}
-
-echo html_writer::select(
-    $materialoptions,
-    'materialid',
-    $materialid,
-    false,
-    [
-        'class' => 'form-control',
-        'id' => 'materialid',
-    ]
+echo local_aiskillnavigator_material_source_selector_html(
+    $readablematerials,
+    $embeddingservice,
+    $courseid,
+    $sourcemode,
+    $selectedmaterialids,
+    'Generation source',
+    'Choose Manual topic only for a generic topic, all materials for full RAG search, or selected materials to use only specific uploaded files.'
 );
-
-echo html_writer::tag(
-    'small',
-    'Choose "Manual topic only" for any generic topic. Choose RAG mode when you want the quiz grounded on indexed teacher materials.',
-    ['class' => 'form-text text-muted']
-);
-
 echo html_writer::end_div();
 
 echo html_writer::start_div('form-group mt-3');
@@ -611,13 +592,8 @@ if ($quiz !== null) {
         'value' => s($difficulty),
     ]);
 
-    echo html_writer::empty_tag('input', [
-        'type' => 'hidden',
-        'name' => 'materialid',
-        'value' => $materialid,
-    ]);
-
-    echo html_writer::empty_tag('input', [
+    echo local_aiskillnavigator_material_source_hidden_fields($sourcemode, $selectedmaterialids);
+echo html_writer::empty_tag('input', [
         'type' => 'hidden',
         'name' => 'quizdata',
         'value' => $encodedquiz,

--- a/scenariogenerator.php
+++ b/scenariogenerator.php
@@ -2,6 +2,7 @@
 // This file is part of Moodle - https://moodle.org/
 
 require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/material_source_helper.php');
 
 use local_aiskillnavigator\service\embedding_service;
 use local_aiskillnavigator\service\real_ai_service;
@@ -89,19 +90,26 @@ $embeddingservice = new embedding_service();
 $totalchunks = $embeddingservice->count_indexed_chunks($courseid);
 
 $readablematerials = local_aiskillnavigator_scenario_get_readable_materials($courseid);
-$selectedmaterials = local_aiskillnavigator_scenario_select_materials($readablematerials, $materialid);
+
+$sourcemode = local_aiskillnavigator_material_source_mode_from_request(-1);
+$selectedmaterialids = local_aiskillnavigator_material_source_selected_ids_from_request($readablematerials);
+$selectedmaterials = local_aiskillnavigator_material_source_selected_materials($readablematerials, $sourcemode, $selectedmaterialids);
+$materialid = local_aiskillnavigator_material_source_legacy_materialid($sourcemode, $selectedmaterialids);
+
+if ($sourcemode === 'selected' && empty($selectedmaterialids)) {
+    $warning = 'Select at least one teacher material or switch to all course materials.';
+}
 
 if ($generate === 1) {
     $service = new real_ai_service();
 
-    if ($materialid === -1) {
+    if ($sourcemode === 'manual') {
         $debugmessage = 'Generation triggered in manual topic mode.';
         $result = $service->generate_xr_scenario($topic, $environment);
     } else if ($totalchunks > 0) {
         $debugmessage = 'Generation triggered in RAG teacher materials mode.';
         $searchquery = $topic !== '' ? $topic : 'virtual learning scenario based on course materials';
-        $searchmaterialid = $materialid > 0 ? $materialid : 0;
-        $results = $embeddingservice->search($searchquery, $courseid, 6, $searchmaterialid);
+        $results = local_aiskillnavigator_material_source_search($embeddingservice, $searchquery, $courseid, 6, $sourcemode, $selectedmaterialids);
 
         if (!empty($results)) {
             $ragcontext = $embeddingservice->build_context($results, 7500);
@@ -195,36 +203,15 @@ echo html_writer::empty_tag('input', [
 ]);
 
 echo html_writer::start_div('form-group');
-
-echo html_writer::tag('label', 'Generation source', ['for' => 'materialid']);
-
-$materialoptions = [
-    -1 => 'Manual topic only (do not use teacher materials)',
-    0 => 'RAG semantic search (all course materials)',
-];
-
-foreach ($readablematerials as $material) {
-    $chunks = $embeddingservice->count_indexed_chunks($courseid, (int) $material->id);
-    $materialoptions[(int) $material->id] = local_aiskillnavigator_scenario_material_short_title($material) . ' â€” RAG chunks: ' . $chunks;
-}
-
-echo html_writer::select(
-    $materialoptions,
-    'materialid',
-    $materialid,
-    false,
-    [
-        'class' => 'form-control',
-        'id' => 'materialid',
-    ]
+echo local_aiskillnavigator_material_source_selector_html(
+    $readablematerials,
+    $embeddingservice,
+    $courseid,
+    $sourcemode,
+    $selectedmaterialids,
+    'Generation source',
+    'Choose Manual topic only for a generic scenario, all materials for full RAG search, or selected materials to generate the scenario only from specific uploaded files.'
 );
-
-echo html_writer::tag(
-    'small',
-    'Choose Manual topic only for any generic scenario, or choose RAG mode for a grounded course scenario based on indexed material chunks.',
-    ['class' => 'form-text text-muted']
-);
-
 echo html_writer::end_div();
 
 echo html_writer::start_div('form-group mt-3');

--- a/tutor.php
+++ b/tutor.php
@@ -2,6 +2,7 @@
 // This file is part of Moodle - https://moodle.org/
 
 require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/material_source_helper.php');
 
 use local_aiskillnavigator\service\embedding_service;
 use local_aiskillnavigator\service\real_ai_service;
@@ -47,25 +48,29 @@ foreach ($materials as $material) {
     }
 }
 
-if ($materialid > 0 && !isset($readablematerials[$materialid])) {
-    $materialid = 0;
-    $warning = 'Selected material not found. RAG search was switched to all course materials.';
-}
-
 $embeddingservice = new embedding_service();
 $totalchunks = $embeddingservice->count_indexed_chunks($courseid);
-$selectedchunkcount = $materialid > 0 ? $embeddingservice->count_indexed_chunks($courseid, $materialid) : $totalchunks;
+
+$sourcemode = local_aiskillnavigator_material_source_mode_from_request(-1);
+$selectedmaterialids = local_aiskillnavigator_material_source_selected_ids_from_request($readablematerials);
+$selectedmaterials = local_aiskillnavigator_material_source_selected_materials($readablematerials, $sourcemode, $selectedmaterialids);
+$selectedchunkcount = local_aiskillnavigator_material_source_count_chunks($embeddingservice, $courseid, $sourcemode, $selectedmaterialids);
+$materialid = local_aiskillnavigator_material_source_legacy_materialid($sourcemode, $selectedmaterialids);
+
+if ($sourcemode === 'selected' && empty($selectedmaterialids)) {
+    $warning = 'Select at least one teacher material or switch to all course materials.';
+}
 
 if ($question !== '') {
     $aiservice = new real_ai_service();
 
-    if ($materialid === -1) {
+    if ($sourcemode === 'manual') {
         $answer = $aiservice->ask_tutor($question);
     } else if ($selectedchunkcount === 0) {
         $warning = 'Non ci sono chunk RAG indicizzati per questa sorgente. '
             . 'Chiedi al docente di usare “Re-index for RAG” in Teacher Materials oppure usa General AI.';
     } else {
-        $results = $embeddingservice->search($question, $courseid, 5, $materialid > 0 ? $materialid : 0);
+        $results = local_aiskillnavigator_material_source_search($embeddingservice, $question, $courseid, 5, $sourcemode, $selectedmaterialids);
 
         if (empty($results)) {
             $warning = 'Nessun chunk rilevante trovato nel RAG index. Prova a riformulare la domanda o usa General AI.';
@@ -135,35 +140,15 @@ echo html_writer::empty_tag('input', [
 ]);
 
 echo html_writer::start_div('form-group');
-echo html_writer::tag('label', 'Answer source', ['for' => 'materialid']);
-
-$materialoptions = [
-    -1 => 'General AI only (do not use teacher materials)',
-    0 => 'RAG semantic search (all course materials)',
-];
-
-foreach ($readablematerials as $material) {
-    $chunks = $embeddingservice->count_indexed_chunks($courseid, (int) $material->id);
-    $materialoptions[(int) $material->id] = $material->title . ' — RAG chunks: ' . $chunks;
-}
-
-echo html_writer::select(
-    $materialoptions,
-    'materialid',
-    $materialid,
-    false,
-    [
-        'class' => 'form-control',
-        'id' => 'materialid',
-    ]
+echo local_aiskillnavigator_material_source_selector_html(
+    $readablematerials,
+    $embeddingservice,
+    $courseid,
+    $sourcemode,
+    $selectedmaterialids,
+    'Answer source',
+    'General AI answers freely. RAG mode searches indexed teacher materials. Use selected materials to ground the answer only on specific uploaded files.'
 );
-
-echo html_writer::tag(
-    'small',
-    'General AI answers freely. RAG mode searches indexed teacher materials and uses only the retrieved chunks as context.',
-    ['class' => 'form-text text-muted']
-);
-
 echo html_writer::end_div();
 
 echo html_writer::start_div('form-group mt-3');
@@ -195,7 +180,7 @@ if ($answer !== '') {
     echo html_writer::start_div('card mt-4');
     echo html_writer::start_div('card-body ai-answer-card');
 
-    if ($materialid === -1) {
+    if ($sourcemode === 'manual') {
         echo html_writer::tag('h3', 'AI answer from general model');
         echo html_writer::tag('p', 'Generated from general AI, without teacher materials.', ['class' => 'text-muted']);
     } else {


### PR DESCRIPTION
Adds support for selecting one or more teacher materials in the AI Tutor, Quiz Generator, Mind Map Generator and XR Scenario Generator.

The generators can now use:
- manual topic only
- all indexed course materials
- only selected teacher materials

This improves control over RAG grounding when the teacher uploads multiple materials.