### PR TITLE
style: clean Moodle chrome on plugin pages

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,6 +13,7 @@ require_login($course);
 $context = context_course::instance($courseid);
 
 $PAGE->set_context($context);
+$PAGE->requires->css(new moodle_url('/local/aiskillnavigator/styles.css'));
 $PAGE->set_url(new moodle_url('/local/aiskillnavigator/index.php', ['courseid' => $courseid]));
 $PAGE->set_title(get_string('pluginname', 'local_aiskillnavigator'));
 $PAGE->set_heading(get_string('pluginname', 'local_aiskillnavigator'));

--- a/mindmapgenerator.php
+++ b/mindmapgenerator.php
@@ -19,6 +19,7 @@ $context = context_course::instance($courseid);
 require_capability('local/aiskillnavigator:viewstudent', $context);
 
 $PAGE->set_context($context);
+$PAGE->requires->css(new moodle_url('/local/aiskillnavigator/styles.css'));
 $PAGE->set_url(new moodle_url('/local/aiskillnavigator/mindmapgenerator.php', ['courseid' => $courseid]));
 $PAGE->set_title(get_string('mindmapgenerator', 'local_aiskillnavigator'));
 $PAGE->set_heading(get_string('mindmapgenerator', 'local_aiskillnavigator'));
@@ -235,11 +236,11 @@ function local_aiskillnavigator_extract_json(string $raw): ?array {
     }
 
     if (empty($decoded['summary'])) {
-        $decoded['summary'] = 'Mappa mentale interattiva generata per organizzare lo studio dell’argomento.';
+        $decoded['summary'] = 'Mappa mentale interattiva generata per organizzare lo studio dellâ€™argomento.';
     }
 
     if (empty($decoded['central_description'])) {
-        $decoded['central_description'] = 'Questo è il concetto centrale della mappa. I rami mostrano definizione, parti principali, funzionamento e applicazioni.';
+        $decoded['central_description'] = 'Questo Ã¨ il concetto centrale della mappa. I rami mostrano definizione, parti principali, funzionamento e applicazioni.';
     }
 
     return $decoded;
@@ -297,7 +298,7 @@ if ($generate) {
             $ragdebug = count($results) . ' RAG chunks retrieved, top similarity: ' . $results[0]->similarity;
 
             foreach ($results as $ragresult) {
-                $ragsources[$ragresult->title . ' — chunk ' . (((int) $ragresult->chunkindex) + 1)] = $ragresult->similarity;
+                $ragsources[$ragresult->title . ' â€” chunk ' . (((int) $ragresult->chunkindex) + 1)] = $ragresult->similarity;
             }
         } else if (!empty($selectedmaterials)) {
             $warning = 'No RAG chunks found for this focus. Falling back to full material context.';
@@ -332,7 +333,7 @@ if ($generate) {
     }
 
     if ($mindmap === null) {
-        $parseerror = 'L’AI ha restituito un JSON incompleto o non valido. Riprova con un materiale più piccolo o con un focus più specifico.';
+        $parseerror = 'Lâ€™AI ha restituito un JSON incompleto o non valido. Riprova con un materiale piÃ¹ piccolo o con un focus piÃ¹ specifico.';
     }
 }
 
@@ -526,7 +527,7 @@ if ($mindmap !== null) {
             'infoTitle' => $branchtitle,
             'infoType' => 'Ramo principale',
             'infoDescription' => $branchdescription,
-            'infoHint' => 'Questo ramo organizza una parte importante dell’argomento.',
+            'infoHint' => 'Questo ramo organizza una parte importante dellâ€™argomento.',
             'title' => $branchdescription,
             'widthConstraint' => ['minimum' => 180, 'maximum' => 230],
         ];

--- a/quizgenerator.php
+++ b/quizgenerator.php
@@ -19,6 +19,7 @@ $context = context_course::instance($courseid);
 require_capability('local/aiskillnavigator:viewstudent', $context);
 
 $PAGE->set_context($context);
+$PAGE->requires->css(new moodle_url('/local/aiskillnavigator/styles.css'));
 $PAGE->set_url(new moodle_url('/local/aiskillnavigator/quizgenerator.php', ['courseid' => $courseid]));
 $PAGE->set_title(get_string('quizgenerator', 'local_aiskillnavigator'));
 $PAGE->set_heading(get_string('quizgenerator', 'local_aiskillnavigator'));
@@ -315,7 +316,7 @@ if ($action === 'grade') {
             $ragdebug = count($results) . ' RAG chunks retrieved, top similarity: ' . $results[0]->similarity;
 
             foreach ($results as $ragresult) {
-                $ragsources[$ragresult->title . ' — chunk ' . (((int) $ragresult->chunkindex) + 1)] = $ragresult->similarity;
+                $ragsources[$ragresult->title . ' â€” chunk ' . (((int) $ragresult->chunkindex) + 1)] = $ragresult->similarity;
             }
         } else if (!empty($selectedmaterials)) {
             $warning = 'No RAG chunks found for this focus. Falling back to full material context.';

--- a/scenariogenerator.php
+++ b/scenariogenerator.php
@@ -19,6 +19,7 @@ $context = context_course::instance($courseid);
 require_capability('local/aiskillnavigator:viewteacher', $context);
 
 $PAGE->set_context($context);
+$PAGE->requires->css(new moodle_url('/local/aiskillnavigator/styles.css'));
 $PAGE->set_url(new moodle_url('/local/aiskillnavigator/scenariogenerator.php', ['courseid' => $courseid]));
 $PAGE->set_title(get_string('scenariogenerator', 'local_aiskillnavigator'));
 $PAGE->set_heading(get_string('scenariogenerator', 'local_aiskillnavigator'));
@@ -117,7 +118,7 @@ if ($generate === 1) {
             $ragdebug = count($results) . ' RAG chunks retrieved, top similarity: ' . $results[0]->similarity;
 
             foreach ($results as $ragresult) {
-                $ragsources[$ragresult->title . ' â€” chunk ' . (((int) $ragresult->chunkindex) + 1)] = $ragresult->similarity;
+                $ragsources[$ragresult->title . ' Ã¢â‚¬â€ chunk ' . (((int) $ragresult->chunkindex) + 1)] = $ragresult->similarity;
             }
         } else if (empty($selectedmaterials)) {
             $warning = 'Non sono stati trovati chunk RAG per questo focus. Usa Manual topic only oppure carica materiali in Teacher Materials.';
@@ -137,7 +138,7 @@ if ($generate === 1) {
     }
 
     if (trim($result) === '' && $warning === '') {
-        $warning = 'La generazione Ã¨ partita, ma il servizio AI ha restituito una risposta vuota.';
+        $warning = 'La generazione ÃƒÂ¨ partita, ma il servizio AI ha restituito una risposta vuota.';
     }
 }
 

--- a/student.php
+++ b/student.php
@@ -15,6 +15,7 @@ $context = context_course::instance($courseid);
 require_capability('local/aiskillnavigator:viewstudent', $context);
 
 $PAGE->set_context($context);
+$PAGE->requires->css(new moodle_url('/local/aiskillnavigator/styles.css'));
 $PAGE->set_url(new moodle_url('/local/aiskillnavigator/student.php', ['courseid' => $courseid]));
 $PAGE->set_title(get_string('studentdashboard', 'local_aiskillnavigator'));
 $PAGE->set_heading(get_string('studentdashboard', 'local_aiskillnavigator'));

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,31 @@
+﻿/* AI Skill Navigator presentation cleanup.
+   Hide Moodle automatic course/page chrome on plugin pages. */
+
+/* Hide Moodle course secondary navigation. */
+body.path-local-aiskillnavigator .secondary-navigation,
+body.path-local-aiskillnavigator #page-header .secondary-navigation,
+body.path-local-aiskillnavigator #page-header .moremenu,
+body.path-local-aiskillnavigator .moremenu.navigation,
+body.path-local-aiskillnavigator nav.moremenu,
+body.path-local-aiskillnavigator [data-region="moremenu"],
+body[id^="page-local-aiskillnavigator"] .secondary-navigation,
+body[id^="page-local-aiskillnavigator"] #page-header .secondary-navigation,
+body[id^="page-local-aiskillnavigator"] #page-header .moremenu,
+body[id^="page-local-aiskillnavigator"] .moremenu.navigation,
+body[id^="page-local-aiskillnavigator"] nav.moremenu,
+body[id^="page-local-aiskillnavigator"] [data-region="moremenu"] {
+    display: none !important;
+}
+
+/* Hide Moodle automatic page title/header.
+   The plugin already renders its own title inside the content. */
+body.path-local-aiskillnavigator #page-header,
+body[id^="page-local-aiskillnavigator"] #page-header {
+    display: none !important;
+}
+
+/* Cleaner spacing for presentation/demo. */
+body.path-local-aiskillnavigator #page,
+body[id^="page-local-aiskillnavigator"] #page {
+    margin-top: 1.5rem;
+}

--- a/teacher.php
+++ b/teacher.php
@@ -15,6 +15,7 @@ $context = context_course::instance($courseid);
 require_capability('local/aiskillnavigator:viewteacher', $context);
 
 $PAGE->set_context($context);
+$PAGE->requires->css(new moodle_url('/local/aiskillnavigator/styles.css'));
 $PAGE->set_url(new moodle_url('/local/aiskillnavigator/teacher.php', ['courseid' => $courseid]));
 $PAGE->set_title('Teacher dashboard');
 $PAGE->set_heading('Teacher dashboard');

--- a/teacher_materials.php
+++ b/teacher_materials.php
@@ -17,6 +17,7 @@ $context = context_course::instance($courseid);
 require_capability('local/aiskillnavigator:managematerials', $context);
 
 $PAGE->set_context($context);
+$PAGE->requires->css(new moodle_url('/local/aiskillnavigator/styles.css'));
 $PAGE->set_url(new moodle_url('/local/aiskillnavigator/teacher_materials.php', ['courseid' => $courseid]));
 $PAGE->set_title('Teacher materials');
 $PAGE->set_heading('Teacher materials');

--- a/tutor.php
+++ b/tutor.php
@@ -18,6 +18,7 @@ $context = context_course::instance($courseid);
 require_capability('local/aiskillnavigator:viewstudent', $context);
 
 $PAGE->set_context($context);
+$PAGE->requires->css(new moodle_url('/local/aiskillnavigator/styles.css'));
 $PAGE->set_url(new moodle_url('/local/aiskillnavigator/tutor.php', ['courseid' => $courseid]));
 $PAGE->set_title(get_string('aitutor', 'local_aiskillnavigator'));
 $PAGE->set_heading(get_string('aitutor', 'local_aiskillnavigator'));
@@ -68,7 +69,7 @@ if ($question !== '') {
         $answer = $aiservice->ask_tutor($question);
     } else if ($selectedchunkcount === 0) {
         $warning = 'Non ci sono chunk RAG indicizzati per questa sorgente. '
-            . 'Chiedi al docente di usare “Re-index for RAG” in Teacher Materials oppure usa General AI.';
+            . 'Chiedi al docente di usare â€œRe-index for RAGâ€ in Teacher Materials oppure usa General AI.';
     } else {
         $results = local_aiskillnavigator_material_source_search($embeddingservice, $question, $courseid, 5, $sourcemode, $selectedmaterialids);
 
@@ -79,7 +80,7 @@ if ($question !== '') {
             $answer = $aiservice->ask_with_rag_context($question, $ragcontext);
 
             foreach ($results as $result) {
-                $sourcekey = $result->title . ' — chunk ' . (((int) $result->chunkindex) + 1);
+                $sourcekey = $result->title . ' â€” chunk ' . (((int) $result->chunkindex) + 1);
                 $ragsources[$sourcekey] = $result->similarity;
             }
 


### PR DESCRIPTION
## Summary

This pull request improves the visual presentation of the AI Skill Navigator Moodle plugin pages.

Main changes:
- hides Moodle secondary course navigation on plugin pages;
- hides duplicated Moodle page header/title;
- keeps the plugin UI cleaner for demo and thesis presentation;
- preserves Moodle integration while reducing visual clutter.

## Why

The plugin pages already render their own title and navigation content.  
The default Moodle course chrome made the interface look duplicated and less clean during presentation.

## Changed pages

The stylesheet is loaded on the main plugin pages, including:

- dashboard/index page;
- AI Tutor;
- Course AI Tutor;
- Quiz Generator;
- Mind Map Generator;
- XR Scenario Generator;
- Student dashboard;
- Teacher dashboard;
- Teacher Materials;
- Settings.

## Manual test

Tested locally with Moodle Docker environment:

- `/local/aiskillnavigator/index.php`
- `/local/aiskillnavigator/tutor.php?courseid=1`
- `/local/aiskillnavigator/quizgenerator.php?courseid=1`
- `/local/aiskillnavigator/mindmapgenerator.php?courseid=1`
- `/local/aiskillnavigator/scenariogenerator.php?courseid=1`

The pages now show a cleaner plugin-focused layout.