### PR TITLE
docs: add provider factory fallback test checklist

### DIFF
--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -12,3 +12,50 @@ After each relevant refactoring step:
 8. Check that no PHP error page is displayed.
 9. Run the PHP lint script.
 10. Purge Moodle cache after deployment.
+
+## AI provider factory selection and fallback
+
+Use this checklist when changing provider selection or provider defaults.
+
+Before testing:
+
+1. Open `Site administration > Plugins > Local plugins > AI Skill Navigator`.
+2. Do not add real production API keys for fallback tests.
+3. After each setting change, save the plugin settings and purge Moodle caches.
+4. Open the AI Tutor page and submit a short prompt such as `Say hello`.
+5. Confirm that the page renders a response or a controlled error, not a PHP
+   fatal error page.
+
+Provider cases:
+
+The settings dropdown currently exposes `ollama`, `openrouter` and `openai`.
+Use Moodle CLI/admin tooling, a database fixture or a temporary local test
+setup for supported factory values that are not visible in the dropdown.
+
+1. Prototype provider:
+   - Direct test config: provider `prototype`, `mock`, or `demo`.
+   - Expected: the demo/prototype response is returned without external API
+     access.
+2. Ollama defaults:
+   - Settings: provider `ollama`, empty endpoint, empty model.
+   - Expected: the factory uses `http://host.docker.internal:11434` and
+     `qwen2.5:3b`.
+3. OpenAI-compatible fallback:
+   - Settings: provider `openai`, `openai_compatible`, `openrouter`, or
+     `groq`; empty endpoint.
+   - Expected: the factory uses the prototype provider instead of calling an
+     empty URL.
+4. OpenAI-compatible configured endpoint:
+   - Settings: provider `openai`, `openai_compatible`, `openrouter`, or
+     `groq`; endpoint set; model empty.
+   - Expected: the factory uses the configured endpoint with model `default`.
+5. DeepSeek defaults:
+   - Direct test config: provider `deepseek`, empty endpoint, empty model.
+   - Expected: the factory uses `https://api.deepseek.com` and `deepseek-chat`.
+6. Unknown provider:
+   - Direct test config: unsupported provider value stored in config.
+   - Expected: the factory falls back to the prototype provider.
+
+When a real external provider is tested, use a non-production test credential
+configured through Moodle settings and verify that the plugin does not store the
+credential in repository files.

--- a/docs/provider-configuration.md
+++ b/docs/provider-configuration.md
@@ -25,6 +25,34 @@ DeepSeek is configured as a dedicated provider name, but internally it uses the 
 - `mock`
 - `demo`
 
+## Factory fallback reference
+
+The provider factory is intentionally tolerant of incomplete demo settings.
+Use this reference when reviewing provider selection changes or running manual
+tests:
+
+The current settings page exposes `ollama`, `openrouter` and `openai` in the
+provider dropdown. Other supported factory values can still be reviewed through
+direct test configuration, such as Moodle CLI/admin tooling, a database fixture
+or a temporary local test setup.
+
+- Empty provider name: uses `deepseek` as the code-level fallback provider.
+- `deepseek` with an empty endpoint: uses `https://api.deepseek.com`.
+- `deepseek` with an empty model: uses `deepseek-chat`.
+- `openai`, `openai_compatible`, `openrouter`, or `groq` with an empty
+  endpoint: falls back to the prototype provider instead of calling an empty
+  URL.
+- `openai`, `openai_compatible`, `openrouter`, or `groq` with a configured
+  endpoint and empty model: uses `default`.
+- `ollama` with an empty endpoint: uses `http://host.docker.internal:11434`.
+- `ollama` with an empty model: uses `qwen2.5:3b`.
+- `prototype`, `mock`, or `demo`: uses the prototype provider.
+- Unknown provider name: falls back to the prototype provider.
+
+For manual tests, prefer `prototype`, `mock`, `demo`, or an intentionally empty
+OpenAI-compatible endpoint when you want to verify fallback behavior without
+making a real external API request.
+
 ## Architecture note
 
 The plugin uses the Strategy Pattern for AI providers.


### PR DESCRIPTION
## Summary
- add a provider factory fallback reference mapped to `ai_provider_factory.php`
- expand the manual test checklist for provider selection and fallback behavior
- note which cases use the settings dropdown and which need direct test configuration

Fixes #11.

## Validation
- inspected `README.md`, `.github/CONTRIBUTING.md`, `LICENSE`, `settings.php`, and `classes/service/ai_provider_factory.php`
- `git diff --check HEAD~1 HEAD` passed
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact` found no leaks
- line-length check on the changed docs only reported one pre-existing long line in `docs/provider-configuration.md:5`

Not run: PHP lint, because `php` is not installed locally. Markdownlint also was not completed because `markdownlint-cli2` is not available as a direct binary and `npx --yes markdownlint-cli2 ...` hung in both default and alternate npm cache attempts. I did not add automated provider-factory unit tests or run a live Moodle manual test pass.