### PR TITLE
Fix final runtime and RAG regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: Plugin CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  php-quality:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: curl, dom, json, libxml, mbstring, simplexml, zip
+          coverage: none
+
+      - name: Lint PHP files
+        run: find plugins tests -type f -name '*.php' -print0 | xargs -0 -n1 php -l
+
+      - name: Validate XMLDB schema
+        run: php tests/xmldb_schema_test.php
+
+      - name: Run embedding configuration tests
+        run: php tests/embedding_config_test.php
+
+      - name: Run RAG API contract tests
+        run: php tests/embedding_contract_test.php
+
+      - name: Run RAG indexing regression tests
+        run: php tests/rag_indexing_test.php
+
+      - name: Reject UTF-8 BOM in PHP files
+        run: php tests/php_bom_test.php
+
+  javascript-quality:
+    name: JavaScript syntax
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check JavaScript syntax
+        run: find plugins -type f -name '*.js' -print0 | xargs -0 -n1 node --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Thanks for improving AI Skill Navigator.
+
+## Development flow
+
+1. Create a branch from `main`.
+2. Keep changes scoped to `local_aiskillnavigator`, `block_aiskillnavigator`, or their documentation.
+3. Preserve the production-safe defaults documented in the README.
+4. Add or update a regression test when fixing a runtime bug.
+5. Open a pull request describing the root cause, user impact, and validation performed.
+
+## Required checks
+
+Run the checks available in your environment before opening a pull request:
+
+```bash
+find plugins tests -type f -name '*.php' -print0 | xargs -0 -n1 php -l
+php tests/embedding_config_test.php
+php tests/embedding_contract_test.php
+php tests/rag_indexing_test.php
+php tests/php_bom_test.php
+php tests/xmldb_schema_test.php
+find plugins -type f -name '*.js' -print0 | xargs -0 -n1 node --check
+```
+
+Also run the Moodle upgrade and the scenarios in `docs/manual-test-checklist.md` against a disposable test course.
+
+## Security and privacy
+
+- Never commit API keys, credentials, student data, or exported course materials.
+- External AI access must remain opt-in globally and per material.
+- Destructive Course Builder actions must remain disabled by default.
+- Use Moodle capabilities, `require_login()`, and sesskey validation for every protected action.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI Skill Navigator
 
+[![Plugin CI](https://github.com/Berserk-hub150/moodle-ai-skill-navigator/actions/workflows/ci.yml/badge.svg)](https://github.com/Berserk-hub150/moodle-ai-skill-navigator/actions/workflows/ci.yml)
+
 AI Skill Navigator is a Moodle plugin suite that adds course-aware AI learning tools for students and teachers.
 
 The package contains:
@@ -80,6 +82,14 @@ The plugin stores course materials, quiz attempts, assessment attempts, saved si
 - Moodle 4.4 or later.
 - PHP version supported by the target Moodle version.
 - Optional cURL support for external AI/search providers.
+
+## Development validation
+
+The repository includes automated checks for PHP 8.1–8.3, XMLDB parsing, JavaScript syntax, UTF-8 BOM regressions, RAG API compatibility, and safe embedding defaults. See [CONTRIBUTING.md](CONTRIBUTING.md) for the local commands and `docs/manual-test-checklist.md` for Moodle runtime scenarios.
+
+## Packaging
+
+For a Moodle installation package, place `plugins/aiskillnavigator` at `local/aiskillnavigator` and `plugins/block_aiskillnavigator` at `blocks/aiskillnavigator`. Do not package the repository root as a single Moodle plugin directory.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security policy
+
+## Supported version
+
+Security fixes are applied to the latest release on the `main` branch.
+
+## Reporting a vulnerability
+
+Please use GitHub's private vulnerability reporting or a private security advisory for this repository. Do not include credentials, personal data, course exports, or exploit details in a public issue.
+
+Include the affected version, reproduction conditions, expected impact, and the smallest safe proof of concept. Reports concerning Moodle authentication, capabilities, sesskeys, external AI data transfer, file handling, or Course Builder actions are treated as security-sensitive.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,19 @@
 # Release notes
 
+## 1.0.4 - Final runtime hardening
+
+Main improvements:
+
+- Fixed automatic RAG indexing after course-resource synchronisation.
+- Added keyword-only embedding fallback for prototype and unsupported chat providers.
+- Prevented external embedding calls unless site and material policies allow them.
+- Added graceful handling when PHP cURL is unavailable.
+- Fixed CLI duplicate-cleanup counters and stale resource cleanup after module deletion.
+- Reconciled legacy database fields and indexes with the current XMLDB schema.
+- Removed UTF-8 BOM from PHP entry points and corrected visible mojibake strings.
+- Declared the block plugin dependency on the local plugin.
+- Added automated PHP, XMLDB, JavaScript, BOM, and RAG contract checks.
+
 ## 1.0.3 - Marketplace hardening version
 
 Main improvements:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,10 +2,9 @@
 
 Possible future improvements:
 
-- Add automated tests for provider factory and prompt builders.
+- Expand automated coverage to provider responses, prompt builders and Moodle integration tests.
 - Add JSON schema validation for generated AI outputs.
 - Improve OCR and PDF extraction for large scanned files.
 - Add more bilingual Italian/English UI strings.
 - Improve quiz difficulty calibration.
 - Add a stable screenshot gallery.
-- Add packaging instructions for Moodle installation.

--- a/plugins/aiskillnavigator/classes/observer.php
+++ b/plugins/aiskillnavigator/classes/observer.php
@@ -44,10 +44,6 @@ class observer {
     public static function course_module_deleted(\core\event\course_module_deleted $event): void {
         global $DB;
 
-        if (!self::auto_sync_enabled()) {
-            return;
-        }
-
         $courseid = (int)$event->courseid;
         $cmid = (int)$event->objectid;
 
@@ -55,15 +51,19 @@ class observer {
             return;
         }
 
+        unset_config('cm_external_ai_' . $cmid, 'local_aiskillnavigator');
+
         try {
             if (!self::table_exists('local_aiskillnav_material')) {
                 return;
             }
 
-            $select = 'courseid = :courseid AND materialtype = :materialtype AND ' . $DB->sql_like('title', ':title', false, false);
+            $select = 'courseid = :courseid AND materialtype = :materialtype'
+                . ' AND (sourcecmid = :sourcecmid OR ' . $DB->sql_like('title', ':title', false, false) . ')';
             $params = [
                 'courseid' => $courseid,
                 'materialtype' => 'course_resource',
+                'sourcecmid' => $cmid,
                 'title' => '%cm #' . $cmid . ']%',
             ];
 
@@ -275,4 +275,3 @@ class observer {
         }
     }
 }
-

--- a/plugins/aiskillnavigator/classes/privacy/provider.php
+++ b/plugins/aiskillnavigator/classes/privacy/provider.php
@@ -333,12 +333,77 @@ class provider implements metadata_provider, request_provider, core_userlist_pro
         }
 
         list($sql, $params) = $DB->get_in_or_equal($materialids, SQL_PARAMS_NAMED, 'aisnmat');
+        $conceptids = [];
+
+        if (self::table_exists('local_aisn_kg_source')) {
+            $conceptids = $DB->get_fieldset_select(
+                'local_aisn_kg_source',
+                'conceptid',
+                'materialid ' . $sql,
+                $params
+            );
+        }
 
         foreach (['local_aiskillnav_chunk', 'local_aisn_kg_source', 'local_aisn_kg_relation'] as $table) {
             if (self::table_exists($table)) {
                 $DB->delete_records_select($table, 'materialid ' . $sql, $params);
             }
         }
+
+        self::delete_orphan_concepts($conceptids);
+    }
+
+    private static function delete_orphan_concepts(array $conceptids): void {
+        global $DB;
+
+        $conceptids = array_values(array_unique(array_filter(array_map('intval', $conceptids))));
+
+        if (empty($conceptids) ||
+            !self::table_exists('local_aisn_kg_concept') ||
+            !self::table_exists('local_aisn_kg_source')) {
+            return;
+        }
+
+        list($sql, $params) = $DB->get_in_or_equal($conceptids, SQL_PARAMS_NAMED, 'aisnconcept');
+        $orphans = $DB->get_fieldset_sql(
+            "SELECT c.id
+               FROM {local_aisn_kg_concept} c
+          LEFT JOIN {local_aisn_kg_source} s ON s.conceptid = c.id
+              WHERE c.id {$sql}
+                AND s.id IS NULL",
+            $params
+        );
+
+        if (empty($orphans)) {
+            return;
+        }
+
+        list($orphansql, $orphanparams) = $DB->get_in_or_equal(
+            $orphans,
+            SQL_PARAMS_NAMED,
+            'aisnorph'
+        );
+
+        if (self::table_exists('local_aisn_kg_relation')) {
+            list($sourcesql, $sourceparams) = $DB->get_in_or_equal(
+                $orphans,
+                SQL_PARAMS_NAMED,
+                'aisnsrc'
+            );
+            list($targetsql, $targetparams) = $DB->get_in_or_equal(
+                $orphans,
+                SQL_PARAMS_NAMED,
+                'aisntgt'
+            );
+
+            $DB->delete_records_select(
+                'local_aisn_kg_relation',
+                'sourceconceptid ' . $sourcesql . ' OR targetconceptid ' . $targetsql,
+                array_merge($sourceparams, $targetparams)
+            );
+        }
+
+        $DB->delete_records_select('local_aisn_kg_concept', 'id ' . $orphansql, $orphanparams);
     }
 
     private static function table_exists(string $table): bool {

--- a/plugins/aiskillnavigator/classes/service/embedding/embedding_client.php
+++ b/plugins/aiskillnavigator/classes/service/embedding/embedding_client.php
@@ -14,7 +14,7 @@ class embedding_client {
     public function generate(string $text): ?array {
         $text = trim($text);
 
-        if ($text === '') {
+        if ($text === '' || $this->config->is_keyword_only()) {
             return null;
         }
 
@@ -37,13 +37,24 @@ class embedding_client {
     }
 
     private function openai(string $text): ?array {
-        $endpoint = preg_replace('#/v1$#', '', preg_replace('#/embeddings$#', '', preg_replace('#/chat/completions$#', '', rtrim($this->config->endpoint, '/'))));
         $headers = $this->config->apikey !== '' ? ['Authorization: Bearer ' . $this->config->apikey] : [];
-        $body = (new embedding_http_client())->post($endpoint . '/v1/embeddings', ['model' => $this->config->model, 'input' => $text], $headers);
+        $body = (new embedding_http_client())->post(
+            $this->openai_url(),
+            ['model' => $this->config->model, 'input' => $text],
+            $headers
+        );
 
         return isset($body['data'][0]['embedding']) && is_array($body['data'][0]['embedding'])
             ? $body['data'][0]['embedding']
             : null;
+    }
+
+    private function openai_url(): string {
+        $endpoint = rtrim($this->config->endpoint, '/');
+        $endpoint = preg_replace('#/(?:chat/completions|embeddings)$#', '', $endpoint);
+        $endpoint = preg_replace('#/v1$#', '', (string)$endpoint);
+
+        return rtrim((string)$endpoint, '/') . '/v1/embeddings';
     }
 
     private function custom(string $text): ?array {

--- a/plugins/aiskillnavigator/classes/service/embedding/embedding_config.php
+++ b/plugins/aiskillnavigator/classes/service/embedding/embedding_config.php
@@ -15,21 +15,41 @@ class embedding_config {
 
     public function __construct() {
         $chatprovider = strtolower(trim((string) get_config('local_aiskillnavigator', 'provider')));
-        $embeddingprovider = strtolower(trim((string) get_config('local_aiskillnavigator', 'embeddingprovider')));
+        $requestedprovider = strtolower(trim((string) get_config('local_aiskillnavigator', 'embeddingprovider')));
+        $chatprovider = $chatprovider !== '' ? $chatprovider : 'prototype';
 
-        if ($embeddingprovider === '' || $embeddingprovider === 'same_as_chat') {
-            $embeddingprovider = $chatprovider !== '' ? $chatprovider : 'ollama';
+        if ($requestedprovider === '' || $requestedprovider === 'same_as_chat') {
+            $embeddingprovider = $this->provider_from_chat($chatprovider);
+        } else {
+            $embeddingprovider = $requestedprovider;
         }
 
-        if (in_array($embeddingprovider, ['openrouter', 'groq', 'deepseek', 'openai_compatible'], true)) {
+        if (in_array($embeddingprovider, [
+            'openrouter',
+            'groq',
+            'deepseek',
+            'mistral',
+            'together',
+            'fireworks',
+            'perplexity',
+            'openai_compatible',
+        ], true)) {
             $embeddingprovider = 'openai';
         }
 
         $chatendpoint = trim((string) get_config('local_aiskillnavigator', 'endpoint'));
         $embeddingendpoint = trim((string) get_config('local_aiskillnavigator', 'embeddingendpoint'));
 
-        $this->provider = $embeddingprovider !== '' ? $embeddingprovider : 'ollama';
-        $this->endpoint = $embeddingendpoint !== '' ? $embeddingendpoint : ($chatendpoint !== '' ? $chatendpoint : 'http://host.docker.internal:11434');
+        $this->provider = in_array($embeddingprovider, ['keyword', 'ollama', 'openai', 'custom_http'], true)
+            ? $embeddingprovider
+            : 'keyword';
+        $this->endpoint = $this->resolve_endpoint(
+            $this->provider,
+            $requestedprovider,
+            $chatprovider,
+            $chatendpoint,
+            $embeddingendpoint
+        );
         $this->model = trim((string) get_config('local_aiskillnavigator', 'embeddingmodel'));
         $this->apikey = trim((string) get_config('local_aiskillnavigator', 'embeddingapikey'));
         $this->requesttemplate = trim((string) get_config('local_aiskillnavigator', 'embeddingrequesttemplate'));
@@ -41,11 +61,95 @@ class embedding_config {
         }
 
         if ($this->model === '') {
-            $this->model = $this->provider === 'ollama' ? 'nomic-embed-text' : 'text-embedding-3-small';
+            if ($this->provider === 'ollama') {
+                $this->model = 'nomic-embed-text';
+            } else if ($this->provider === 'openai') {
+                $this->model = 'text-embedding-3-small';
+            } else {
+                $this->model = 'keyword';
+            }
         }
 
         if ($this->responsepath === '') {
             $this->responsepath = 'data.0.embedding';
         }
+    }
+
+    public function is_keyword_only(): bool {
+        return $this->provider === 'keyword' || $this->endpoint === '';
+    }
+
+    public function uses_external_service(): bool {
+        if ($this->is_keyword_only()) {
+            return false;
+        }
+
+        $parts = parse_url($this->endpoint);
+        $host = strtolower((string)($parts['host'] ?? ''));
+
+        if ($host === '') {
+            return false;
+        }
+
+        return !in_array($host, [
+            'localhost',
+            '127.0.0.1',
+            '::1',
+            'host.docker.internal',
+            'ollama',
+        ], true) && !str_ends_with($host, '.local');
+    }
+
+    private function provider_from_chat(string $chatprovider): string {
+        if (in_array($chatprovider, ['ollama', 'local', 'local_ollama'], true)) {
+            return 'ollama';
+        }
+
+        if ($chatprovider === 'openai') {
+            return 'openai';
+        }
+
+        // Prototype, Gemini and Anthropic do not use the OpenAI embeddings
+        // protocol implemented by this plugin. Use deterministic keyword
+        // fallback instead of silently contacting an unrelated endpoint.
+        return 'keyword';
+    }
+
+    private function resolve_endpoint(
+        string $provider,
+        string $requestedprovider,
+        string $chatprovider,
+        string $chatendpoint,
+        string $embeddingendpoint
+    ): string {
+        if ($provider === 'keyword') {
+            return '';
+        }
+
+        if ($embeddingendpoint !== '') {
+            return $embeddingendpoint;
+        }
+
+        if ($provider === 'custom_http') {
+            return '';
+        }
+
+        if ($provider === 'ollama') {
+            return in_array($chatprovider, ['ollama', 'local', 'local_ollama'], true) && $chatendpoint !== ''
+                ? $chatendpoint
+                : 'http://host.docker.internal:11434';
+        }
+
+        if ($provider === 'openai') {
+            if (($requestedprovider === '' || $requestedprovider === 'same_as_chat') && $chatprovider === 'openai') {
+                return $chatendpoint !== '' ? $chatendpoint : 'https://api.openai.com/v1';
+            }
+
+            return $chatendpoint !== '' && $chatprovider === 'openai'
+                ? $chatendpoint
+                : 'https://api.openai.com/v1';
+        }
+
+        return '';
     }
 }

--- a/plugins/aiskillnavigator/classes/service/embedding/embedding_http_client.php
+++ b/plugins/aiskillnavigator/classes/service/embedding/embedding_http_client.php
@@ -14,6 +14,11 @@ class embedding_http_client {
             return null;
         }
 
+        if (!function_exists('curl_init')) {
+            debugging('AI Skill Navigator embeddings skipped: PHP cURL extension is not available.', DEBUG_DEVELOPER);
+            return null;
+        }
+
         $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         if ($json === false) {

--- a/plugins/aiskillnavigator/classes/service/embedding/embedding_indexer.php
+++ b/plugins/aiskillnavigator/classes/service/embedding/embedding_indexer.php
@@ -12,7 +12,13 @@ class embedding_indexer {
         $this->config = $config;
     }
 
-    public function index(int $materialid, int $courseid, string $title, string $content): array {
+    public function index(
+        int $materialid,
+        int $courseid,
+        string $title,
+        string $content,
+        bool $generateembeddings = true
+    ): array {
         $content = trim($content);
 
         if ($content === '') {
@@ -27,23 +33,40 @@ class embedding_indexer {
             return ['success' => false, 'chunks' => 0, 'message' => 'No chunks generated from this material.'];
         }
 
-        return $this->store($repo, $chunks, $materialid, $courseid, $title);
+        return $this->store($repo, $chunks, $materialid, $courseid, $title, $generateembeddings);
     }
 
-    private function store(chunk_repository $repo, array $chunks, int $materialid, int $courseid, string $title): array {
+    private function store(
+        chunk_repository $repo,
+        array $chunks,
+        int $materialid,
+        int $courseid,
+        string $title,
+        bool $generateembeddings
+    ): array {
         $indexed = 0; $failed = 0;
         $client = new embedding_client($this->config);
         $recordbuilder = new embedding_chunk_record($this->config);
 
         foreach ($chunks as $index => $chunktext) {
-            $embedding = $client->generate($chunktext);
-            $failed += $embedding === null ? 1 : 0;
+            $embedding = $generateembeddings ? $client->generate($chunktext) : null;
+
+            if ($generateembeddings && $embedding === null) {
+                $failed++;
+            }
+
             $repo->insert($recordbuilder->make($materialid, $courseid, $title, $index, $chunktext, $embedding ?? []));
             $indexed++;
         }
 
         $message = "Indexed {$indexed} chunks from \"{$title}\".";
-        $message .= $failed > 0 ? " {$failed} chunks were saved without embeddings and will use keyword fallback." : '';
+
+        if (!$generateembeddings) {
+            $message .= ' Embeddings were skipped; keyword fallback is active.';
+        } else if ($failed > 0) {
+            $message .= " {$failed} chunks were saved without embeddings and will use keyword fallback.";
+        }
+
         return ['success' => true, 'chunks' => $indexed, 'message' => $message];
     }
 }

--- a/plugins/aiskillnavigator/classes/service/embedding/embedding_searcher.php
+++ b/plugins/aiskillnavigator/classes/service/embedding/embedding_searcher.php
@@ -12,7 +12,13 @@ class embedding_searcher {
         $this->config = $config;
     }
 
-    public function search(string $query, int $courseid, int $topk, int $materialid): array {
+    public function search(
+        string $query,
+        int $courseid,
+        int $topk,
+        int $materialid,
+        bool $generateembedding = true
+    ): array {
         $query = trim($query) !== '' ? trim($query) : 'course material concepts learning objectives';
         $topk = $topk > 0 ? $topk : 5;
         $chunks = (new chunk_repository())->load($courseid, $materialid);
@@ -21,7 +27,9 @@ class embedding_searcher {
             return [];
         }
 
-        $queryembedding = (new embedding_client($this->config))->generate($query);
+        $queryembedding = $generateembedding
+            ? (new embedding_client($this->config))->generate($query)
+            : null;
         $scored = [];
 
         foreach ($chunks as $chunk) {

--- a/plugins/aiskillnavigator/classes/service/embedding_service.php
+++ b/plugins/aiskillnavigator/classes/service/embedding_service.php
@@ -16,8 +16,41 @@ class embedding_service {
         $this->config = new embedding\embedding_config();
     }
 
-    public function index_material(int $materialid, int $courseid, string $title, string $content): array {
-        return (new embedding\embedding_indexer($this->config))->index($materialid, $courseid, $title, $content);
+    public function index_material(
+        int $materialid,
+        ?int $courseid = null,
+        ?string $title = null,
+        ?string $content = null
+    ): array {
+        global $DB;
+
+        $material = $DB->get_record('local_aiskillnav_material', ['id' => $materialid]);
+
+        if (!$material) {
+            return ['success' => false, 'chunks' => 0, 'message' => 'Material not found.'];
+        }
+
+        $courseid = $courseid ?? (int)$material->courseid;
+        $title = $title ?? (string)$material->title;
+        $content = $content ?? (string)$material->content;
+
+        if ($courseid !== (int)$material->courseid) {
+            return ['success' => false, 'chunks' => 0, 'message' => 'Material does not belong to the requested course.'];
+        }
+
+        $generateembeddings = $this->can_generate_embeddings_for_material($material);
+
+        return (new embedding\embedding_indexer($this->config))->index(
+            $materialid,
+            $courseid,
+            $title,
+            $content,
+            $generateembeddings
+        );
+    }
+
+    public function index_material_by_id(int $materialid): array {
+        return $this->index_material($materialid);
     }
 
     public function delete_material_chunks(int $materialid): void {
@@ -29,10 +62,42 @@ class embedding_service {
     }
 
     public function search(string $query, int $courseid, int $topk = 0, int $materialid = 0): array {
-        return (new embedding\embedding_searcher($this->config))->search($query, $courseid, $topk, $materialid);
+        $generateembedding = !$this->config->uses_external_service() || $this->external_ai_approved();
+
+        return (new embedding\embedding_searcher($this->config))->search(
+            $query,
+            $courseid,
+            $topk,
+            $materialid,
+            $generateembedding
+        );
     }
 
     public function build_context(array $results, int $maxchars = 6000): string {
         return (new embedding\rag_context_builder())->build($results, $maxchars);
+    }
+
+    private function can_generate_embeddings_for_material(\stdClass $material): bool {
+        if ($this->config->is_keyword_only()) {
+            return false;
+        }
+
+        if (!$this->config->uses_external_service()) {
+            return true;
+        }
+
+        if (!$this->external_ai_approved()) {
+            return false;
+        }
+
+        if (isset($material->externalaiallowed)) {
+            return (int)$material->externalaiallowed === 1;
+        }
+
+        return isset($material->aipolicy) && (string)$material->aipolicy === 'external_allowed';
+    }
+
+    private function external_ai_approved(): bool {
+        return (string)get_config('local_aiskillnavigator', 'externalaiapproved') === '1';
     }
 }

--- a/plugins/aiskillnavigator/classes/service/provider/http_json_client.php
+++ b/plugins/aiskillnavigator/classes/service/provider/http_json_client.php
@@ -19,6 +19,16 @@ class http_json_client {
             ];
         }
 
+        if (!function_exists('curl_init')) {
+            return [
+                'ok' => false,
+                'status' => 0,
+                'error' => 'PHP cURL extension is not available.',
+                'raw' => '',
+                'body' => null,
+            ];
+        }
+
         $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         if ($json === false) {

--- a/plugins/aiskillnavigator/classes/service/web_search_service.php
+++ b/plugins/aiskillnavigator/classes/service/web_search_service.php
@@ -157,6 +157,10 @@ class web_search_service {
             return ['ok' => false, 'error' => $validation];
         }
 
+        if (!function_exists('curl_init')) {
+            return ['ok' => false, 'error' => 'PHP cURL extension is not available.'];
+        }
+
         $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         if ($json === false) {
@@ -194,6 +198,10 @@ class web_search_service {
         if ($validation !== '') {
             debugging('AI Skill Navigator search endpoint blocked: ' . $validation, DEBUG_DEVELOPER);
             return ['ok' => false, 'error' => $validation];
+        }
+
+        if (!function_exists('curl_init')) {
+            return ['ok' => false, 'error' => 'PHP cURL extension is not available.'];
         }
 
         $curl = curl_init($url);

--- a/plugins/aiskillnavigator/cli/sync_course_resources.php
+++ b/plugins/aiskillnavigator/cli/sync_course_resources.php
@@ -55,14 +55,14 @@ function local_aisn_cli_print_sync_result(int $courseid, array $result): void {
     echo "Updated: " . (int)($result['updated'] ?? 0) . "\n";
     echo "Skipped: " . (int)($result['skipped'] ?? 0) . "\n";
 
-    if (array_key_exists('deletedduplicates', $result)) {
-        echo "Deleted duplicates: " . (int)$result['deletedduplicates'] . "\n";
+    if (array_key_exists('duplicatesdeleted', $result)) {
+        echo "Deleted duplicates: " . (int)$result['duplicatesdeleted'] . "\n";
     }
 }
 
 if (!empty($options['all'])) {
     $courseids = $DB->get_fieldset_select('course', 'id', 'id <> ?', [SITEID]);
-    $total = ['created' => 0, 'updated' => 0, 'skipped' => 0, 'deletedduplicates' => 0];
+    $total = ['created' => 0, 'updated' => 0, 'skipped' => 0, 'duplicatesdeleted' => 0];
 
     foreach ($courseids as $id) {
         $courseid = (int)$id;
@@ -78,7 +78,7 @@ if (!empty($options['all'])) {
     echo "Total created: {$total['created']}\n";
     echo "Total updated: {$total['updated']}\n";
     echo "Total skipped: {$total['skipped']}\n";
-    echo "Total deleted duplicates: {$total['deletedduplicates']}\n";
+    echo "Total deleted duplicates: {$total['duplicatesdeleted']}\n";
     exit(0);
 }
 

--- a/plugins/aiskillnavigator/db/install.xml
+++ b/plugins/aiskillnavigator/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="local/aiskillnavigator/db" VERSION="2026060101" COMMENT="XMLDB file for local_aiskillnavigator">
+<XMLDB PATH="local/aiskillnavigator/db" VERSION="2026080600" COMMENT="XMLDB file for local_aiskillnavigator">
   <TABLES>
     <TABLE NAME="local_aiskillnav_material" COMMENT="Teacher course materials">
       <FIELDS>
@@ -49,6 +49,7 @@
       <INDEXES>
         <INDEX NAME="courseid_ix" UNIQUE="false" FIELDS="courseid"/>
         <INDEX NAME="userid_ix" UNIQUE="false" FIELDS="userid"/>
+        <INDEX NAME="topic_ix" UNIQUE="false" FIELDS="topic"/>
       </INDEXES>
     </TABLE>
 
@@ -95,6 +96,7 @@
       </KEYS>
       <INDEXES>
         <INDEX NAME="courseid_ix" UNIQUE="false" FIELDS="courseid"/>
+        <INDEX NAME="userid_ix" UNIQUE="false" FIELDS="userid"/>
         <INDEX NAME="type_ix" UNIQUE="false" FIELDS="assessmenttype"/>
         <INDEX NAME="visible_ix" UNIQUE="false" FIELDS="visible"/>
       </INDEXES>

--- a/plugins/aiskillnavigator/db/upgrade.php
+++ b/plugins/aiskillnavigator/db/upgrade.php
@@ -411,5 +411,114 @@ function xmldb_local_aiskillnavigator_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026061201, 'local', 'aiskillnavigator');
     }
 
+    if ($oldversion < 2026080600) {
+        $table = new xmldb_table('local_aiskillnav_material');
+
+        if ($dbman->table_exists($table)) {
+            $field = new xmldb_field(
+                'aipolicy',
+                XMLDB_TYPE_CHAR,
+                '32',
+                null,
+                XMLDB_NOTNULL,
+                null,
+                'local_only',
+                'externalaiallowed'
+            );
+
+            if ($dbman->field_exists($table, $field)) {
+                $DB->execute("UPDATE {local_aiskillnav_material}
+                                SET aipolicy = CASE
+                                    WHEN externalaiallowed = 1 THEN 'external_allowed'
+                                    ELSE 'local_only'
+                                END
+                              WHERE aipolicy IS NULL OR aipolicy = ''");
+                $dbman->change_field_type($table, $field);
+                $dbman->change_field_notnull($table, $field);
+                $dbman->change_field_default($table, $field);
+            }
+        }
+
+        $table = new xmldb_table('local_aiskillnav_chunk');
+
+        if ($dbman->table_exists($table)) {
+            $field = new xmldb_field(
+                'embeddingmodel',
+                XMLDB_TYPE_CHAR,
+                '255',
+                null,
+                XMLDB_NOTNULL,
+                null,
+                '',
+                'embedding'
+            );
+
+            if ($dbman->field_exists($table, $field)) {
+                $DB->execute("UPDATE {local_aiskillnav_chunk}
+                                SET embeddingmodel = ''
+                              WHERE embeddingmodel IS NULL");
+                $dbman->change_field_type($table, $field);
+                $dbman->change_field_notnull($table, $field);
+                $dbman->change_field_default($table, $field);
+            }
+        }
+
+        $table = new xmldb_table('local_aiskillnav_attempt');
+
+        if ($dbman->table_exists($table)) {
+            $index = new xmldb_index('topic_ix', XMLDB_INDEX_NOTUNIQUE, ['topic']);
+
+            if (!$dbman->index_exists($table, $index)) {
+                $dbman->add_index($table, $index);
+            }
+        }
+
+        $table = new xmldb_table('local_aiskillnav_assessment');
+
+        if ($dbman->table_exists($table)) {
+            $index = new xmldb_index('userid_ix', XMLDB_INDEX_NOTUNIQUE, ['userid']);
+
+            if (!$dbman->index_exists($table, $index)) {
+                $dbman->add_index($table, $index);
+            }
+        }
+
+        $table = new xmldb_table('local_aiskillnav_sim');
+
+        if ($dbman->table_exists($table)) {
+            $field = new xmldb_field(
+                'source',
+                XMLDB_TYPE_CHAR,
+                '40',
+                null,
+                XMLDB_NOTNULL,
+                null,
+                'ai_generated',
+                'description'
+            );
+
+            if ($dbman->field_exists($table, $field)) {
+                $dbman->change_field_default($table, $field);
+            }
+
+            $field = new xmldb_field(
+                'url',
+                XMLDB_TYPE_TEXT,
+                null,
+                null,
+                null,
+                null,
+                null,
+                'title'
+            );
+
+            if ($dbman->field_exists($table, $field)) {
+                $dbman->change_field_notnull($table, $field);
+            }
+        }
+
+        upgrade_plugin_savepoint(true, 2026080600, 'local', 'aiskillnavigator');
+    }
+
     return true;
 }

--- a/plugins/aiskillnavigator/includes/course_resource_sync.php
+++ b/plugins/aiskillnavigator/includes/course_resource_sync.php
@@ -957,25 +957,24 @@ if (!function_exists('local_aiskillnavigator_try_index_synced_materials')) {
             return;
         }
 
-        try {
-            $service = new \local_aiskillnavigator\service\embedding_service();
+        $service = new \local_aiskillnavigator\service\embedding_service();
 
-            foreach ($materialids as $materialid) {
-                if (!local_aisn_crs_get_records(['id' => (int)$materialid])) {
+        foreach ($materialids as $materialid) {
+            try {
+                $records = local_aisn_crs_get_records(['id' => (int)$materialid]);
+
+                if (empty($records)) {
                     continue;
                 }
 
-                if (method_exists($service, 'index_material')) {
-                    $service->index_material((int)$materialid);
-                } else if (method_exists($service, 'index_material_by_id')) {
-                    $service->index_material_by_id((int)$materialid);
-                } else if (method_exists($service, 'index_teacher_material')) {
-                    $service->index_teacher_material((int)$materialid);
-                }
+                $service->index_material((int)$materialid, $courseid);
+            } catch (Throwable $e) {
+                debugging(
+                    'AI Skill Navigator course material auto-index skipped for material '
+                        . (int)$materialid . ': ' . $e->getMessage(),
+                    DEBUG_DEVELOPER
+                );
             }
-        } catch (Throwable $e) {
-            debugging('AI Skill Navigator course material auto-index skipped: ' . $e->getMessage(), DEBUG_DEVELOPER);
         }
     }
 }
-

--- a/plugins/aiskillnavigator/includes/document_ocr_toggle_helper.php
+++ b/plugins/aiskillnavigator/includes/document_ocr_toggle_helper.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/plugins/aiskillnavigator/lang/en/local_aiskillnavigator.php
+++ b/plugins/aiskillnavigator/lang/en/local_aiskillnavigator.php
@@ -30,6 +30,7 @@ $string['embeddingmodel_desc'] = 'Model used for generating RAG embeddings. For 
 $string['local/aiskillnavigator:viewstudent'] = 'Use student AI tools';
 $string['local/aiskillnavigator:viewteacher'] = 'Use teacher AI tools';
 $string['local/aiskillnavigator:managematerials'] = 'Manage teacher AI materials';
+$string['local/aiskillnavigator:manageassessments'] = 'Manage AI assessments';
 $string['privacy:metadata:configured_ai_provider'] = 'Optional external AI provider configured by the site administrator.';
 $string['privacy:metadata:local_aiskillnav_material'] = 'Course materials stored for AI-assisted learning.';
 $string['privacy:metadata:local_aiskillnav_attempt'] = 'Student AI quiz attempts.';

--- a/plugins/aiskillnavigator/lib.php
+++ b/plugins/aiskillnavigator/lib.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -92,6 +92,17 @@ function local_aiskillnavigator_coursemodule_edit_post_actions($data, $course) {
         return $data;
     }
 
+    $modname = trim((string)($data->modulename ?? $data->modname ?? ''));
+
+    if ($modname === '') {
+        $cm = get_coursemodule_from_id('', (int)$data->coursemodule, 0, false, IGNORE_MISSING);
+        $modname = $cm && !empty($cm->modname) ? (string)$cm->modname : '';
+    }
+
+    if ($modname === '' || !in_array($modname, local_aiskillnavigator_ai_policy_supported_modnames(), true)) {
+        return $data;
+    }
+
     $cmid = (int)$data->coursemodule;
     $allowed = !empty($data->local_aiskillnavigator_external_ai);
 
@@ -103,7 +114,9 @@ function local_aiskillnavigator_coursemodule_edit_post_actions($data, $course) {
 
     $syncfile = $CFG->dirroot . '/local/aiskillnavigator/includes/course_resource_sync.php';
 
-    if (file_exists($syncfile)) {
+    $autosyncenabled = (string)get_config('local_aiskillnavigator', 'autosynccourseresources') === '1';
+
+    if ($autosyncenabled && file_exists($syncfile)) {
         require_once($syncfile);
 
         if (function_exists('local_aiskillnavigator_sync_course_resources')) {
@@ -149,7 +162,9 @@ function local_aiskillnavigator_apply_cm_ai_policy_to_material(
     foreach ($materials as $material) {
         $title = (string)($material->title ?? '');
 
-        if (!str_starts_with($title, $prefix)) {
+        $sourcecmid = isset($material->sourcecmid) ? (int)$material->sourcecmid : 0;
+
+        if ($sourcecmid !== $cmid && !str_starts_with($title, $prefix)) {
             continue;
         }
 
@@ -170,4 +185,3 @@ function local_aiskillnavigator_apply_cm_ai_policy_to_material(
 function local_aiskillnavigator_before_footer(): string {
     return '';
 }
-

--- a/plugins/aiskillnavigator/pages/assessment.php
+++ b/plugins/aiskillnavigator/pages/assessment.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 require_once(__DIR__ . '/../../../config.php');
 require_once(__DIR__ . '/../includes/role_guard.php');
@@ -354,4 +354,3 @@ echo html_writer::end_div();
 echo local_aisn_back_to_course_autofix((int)($courseid ?? optional_param('courseid', optional_param('id', 0, PARAM_INT), PARAM_INT)));
 if (function_exists('local_aisn_ai_output_formatter_assets')) { echo local_aisn_ai_output_formatter_assets(); }
 echo $OUTPUT->footer();
-

--- a/plugins/aiskillnavigator/pages/mindmapgenerator.php
+++ b/plugins/aiskillnavigator/pages/mindmapgenerator.php
@@ -237,7 +237,7 @@ function local_aiskillnavigator_mm_fallback(string $topic): array {
                 'summary' => 'Mostra casi pratici e situazioni in cui il concetto viene applicato.',
                 'children' => [
                     ['title' => 'Caso semplice', 'summary' => 'Un esempio introduttivo utile per iniziare.'],
-                    ['title' => 'Caso avanzato', 'summary' => 'Un esempio piÃ¹ completo per approfondire.'],
+                    ['title' => 'Caso avanzato', 'summary' => 'Un esempio più completo per approfondire.'],
                 ],
             ],
             [
@@ -1573,6 +1573,5 @@ function local_aiskillnavigator_mindmap_live_web_assets(int $courseid): string {
 </script>
 HTML;
 }
-
 
 

--- a/plugins/aiskillnavigator/pages/quiz_error_video.php
+++ b/plugins/aiskillnavigator/pages/quiz_error_video.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 require_once(__DIR__ . '/../../../config.php');
 require_once(__DIR__ . '/../includes/role_guard.php');

--- a/plugins/aiskillnavigator/pages/quizgenerator.php
+++ b/plugins/aiskillnavigator/pages/quizgenerator.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 // This file is part of Moodle - https://moodle.org/
 
 require_once(__DIR__ . '/../../../config.php');
@@ -931,12 +931,12 @@ function local_aiskillnavigator_quiz_video_remediation_assets(int $courseid): st
                 return;
             }
 
-            const label = data.isvideo ? "Video consigliato dopo lâ€™errore" : "Risorsa consigliata dopo lâ€™errore";
+            const label = data.isvideo ? "Video consigliato dopo l'errore" : "Risorsa consigliata dopo l'errore";
 
             box.className = "aisn-video-remediation-card";
             box.innerHTML =
                 '<span class="aisn-video-remediation-chip">' + escapeHtml(label) + '</span>' +
-                '<h4>Recupero adattivo guidato dallâ€™errore</h4>' +
+                "<h4>Recupero adattivo guidato dall'errore</h4>" +
                 '<p><strong>Ability to improve:</strong> ' + escapeHtml(skill) + '</p>' +
                 '<p><a href="' + escapeHtml(data.url) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(data.title || data.url) + '</a></p>' +
                 (data.snippet ? '<p>' + escapeHtml(data.snippet) + '</p>' : '') +
@@ -1628,7 +1628,5 @@ function local_aiskillnavigator_quiz_tavily_video_assets_final_single(int $cours
 </script>
 HTML;
 }
-
-
 
 

--- a/plugins/aiskillnavigator/pages/simulator_finder.php
+++ b/plugins/aiskillnavigator/pages/simulator_finder.php
@@ -343,8 +343,8 @@ if ($action === 'generate') {
         $prompt .= "2. Istruzioni\n";
         $prompt .= "3. Simulatore/tool consigliato\n";
         $prompt .= "4. Link/fonte\n";
-        $prompt .= "5. PerchÃ© questo simulatore Ã¨ adatto\n";
-        $prompt .= "6. Alternativa se nessun simulatore Ã¨ disponibile\n";
+        $prompt .= "5. Perché questo simulatore è adatto\n";
+        $prompt .= "6. Alternativa se nessun simulatore è disponibile\n";
         $prompt .= "7. Criteri di valutazione\n";
 
         $result = local_aiskillnavigator_sim_call_ai(
@@ -629,6 +629,5 @@ echo html_writer::end_div();
 echo local_aisn_back_to_course_autofix((int)($courseid ?? optional_param('courseid', optional_param('id', 0, PARAM_INT), PARAM_INT)));
 if (function_exists('local_aisn_ai_output_formatter_assets')) { echo local_aisn_ai_output_formatter_assets(); }
 echo $OUTPUT->footer();
-
 
 

--- a/plugins/aiskillnavigator/pages/teacher_materials.php
+++ b/plugins/aiskillnavigator/pages/teacher_materials.php
@@ -272,7 +272,7 @@ function local_aisn_tm_delete_material(stdClass $material): void {
             debugging('AI Skill Navigator material duplicate lookup failed before delete: ' . $e->getMessage(), DEBUG_DEVELOPER);
         }
 
-        // Questa Ã¨ la parte che mancava: elimina davvero la risorsa/attivitÃ  dal corso Moodle.
+        // Elimina anche la risorsa o attività corrispondente dal corso Moodle.
         try {
             $cm = get_coursemodule_from_id('', $cmid, $courseid, false, IGNORE_MISSING);
 
@@ -520,4 +520,3 @@ if (function_exists('local_aiskillnavigator_mojibake_guard')) {
     echo local_aiskillnavigator_mojibake_guard();
 }
 echo $OUTPUT->footer();
-

--- a/plugins/aiskillnavigator/pages/tutor.php
+++ b/plugins/aiskillnavigator/pages/tutor.php
@@ -20,11 +20,11 @@ if (!function_exists('local_aisn_tutor_ai_format_rules_clean_v2')) {
             . "Regole di risposta obbligatorie:\n"
             . "- Rispondi in italiano.\n"
             . "- Usa Markdown pulito e ben strutturato.\n"
-            . "- Usa titoli brevi con ## quando la risposta contiene piÃƒÂ¹ parti.\n"
+            . "- Usa titoli brevi con ## quando la risposta contiene più parti.\n"
             . "- Usa elenchi puntati per caratteristiche, vantaggi, esempi, differenze e casi d'uso.\n"
             . "- Se mostri codice o comandi, scegli tu il linguaggio corretto del blocco markdown in base al contenuto.\n"
-            . "- Non etichettare un blocco come javascript se non ÃƒÂ¨ realmente JavaScript applicativo.\n"
-            . "- Per comandi database usa il linguaggio piÃƒÂ¹ adatto se lo riconosci, ad esempio sql, mongodb, cql, cypher, redis, oppure text se non sei sicuro.\n"
+            . "- Non etichettare un blocco come javascript se non è realmente JavaScript applicativo.\n"
+            . "- Per comandi database usa il linguaggio più adatto se lo riconosci, ad esempio sql, mongodb, cql, cypher, redis, oppure text se non sei sicuro.\n"
             . "- Non iniziare ripetendo il nome del file materiale.\n"
             . "- Non scrivere tutto in un unico paragrafo lungo.\n"
             . "- Chiudi con una breve sezione ## In sintesi quando utile.\n";
@@ -38,11 +38,11 @@ if (!function_exists('local_aisn_tutor_ai_format_rules_clean')) {
             . "Regole di risposta obbligatorie:\n"
             . "- Rispondi in italiano.\n"
             . "- Usa Markdown pulito e ben strutturato.\n"
-            . "- Usa titoli brevi con ## quando la risposta contiene piÃƒÂ¹ parti.\n"
+            . "- Usa titoli brevi con ## quando la risposta contiene più parti.\n"
             . "- Usa elenchi puntati per caratteristiche, vantaggi, esempi, differenze e casi d'uso.\n"
             . "- Se mostri codice o comandi, scegli tu il linguaggio corretto del blocco markdown in base al contenuto.\n"
-            . "- Non etichettare un blocco come javascript se non ÃƒÂ¨ realmente JavaScript applicativo.\n"
-            . "- Per comandi database usa il linguaggio piÃƒÂ¹ adatto se lo riconosci, ad esempio sql, mongodb, cql, cypher, redis, oppure text se non sei sicuro.\n"
+            . "- Non etichettare un blocco come javascript se non è realmente JavaScript applicativo.\n"
+            . "- Per comandi database usa il linguaggio più adatto se lo riconosci, ad esempio sql, mongodb, cql, cypher, redis, oppure text se non sei sicuro.\n"
             . "- Non iniziare ripetendo il nome del file materiale.\n"
             . "- Non scrivere tutto in un unico paragrafo lungo.\n"
             . "- Chiudi con una breve sezione ## In sintesi quando utile.\n";
@@ -484,7 +484,6 @@ function local_aiskillnavigator_tutor_signal_capture_assets(int $courseid): stri
 </script>
 HTML;
 }
-
 
 
 

--- a/plugins/aiskillnavigator/version.php
+++ b/plugins/aiskillnavigator/version.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 // This file is part of Moodle - https://moodle.org/
 
 defined('MOODLE_INTERNAL') || die();
@@ -6,8 +6,7 @@ defined('MOODLE_INTERNAL') || die();
 $plugin = new stdClass();
 
 $plugin->component = 'local_aiskillnavigator';
-$plugin->version = 2026061299;
+$plugin->version = 2026080600;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.0.3';
-
+$plugin->release = '1.0.4';

--- a/plugins/block_aiskillnavigator/version.php
+++ b/plugins/block_aiskillnavigator/version.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 // This file is part of Moodle - https://moodle.org/
 
 defined('MOODLE_INTERNAL') || die();
@@ -6,9 +6,11 @@ defined('MOODLE_INTERNAL') || die();
 $plugin = new stdClass();
 
 $plugin->component = 'block_aiskillnavigator';
-$plugin->version = 2026061299;
+$plugin->version = 2026080600;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.0.3';
+$plugin->release = '1.0.4';
 $plugin->cron = 0;
-
+$plugin->dependencies = [
+    'local_aiskillnavigator' => 2026080600,
+];

--- a/tests/embedding_config_test.php
+++ b/tests/embedding_config_test.php
@@ -1,0 +1,89 @@
+<?php
+
+define('MOODLE_INTERNAL', true);
+
+$testconfig = [];
+
+function get_config($component, $name) {
+    global $testconfig;
+
+    return array_key_exists($name, $testconfig) ? $testconfig[$name] : false;
+}
+
+require_once(__DIR__ . '/../plugins/aiskillnavigator/classes/service/embedding/embedding_config.php');
+require_once(__DIR__ . '/../plugins/aiskillnavigator/classes/service/embedding/embedding_client.php');
+
+use local_aiskillnavigator\service\embedding\embedding_config;
+use local_aiskillnavigator\service\embedding\embedding_client;
+
+function assert_same($expected, $actual, string $message): void {
+    if ($expected !== $actual) {
+        fwrite(
+            STDERR,
+            $message . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true) . PHP_EOL
+        );
+        exit(1);
+    }
+}
+
+function embedding_config_for(array $values): embedding_config {
+    global $testconfig;
+
+    $testconfig = $values;
+    return new embedding_config();
+}
+
+$config = embedding_config_for([
+    'provider' => 'prototype',
+    'embeddingprovider' => 'same_as_chat',
+]);
+assert_same('keyword', $config->provider, 'Prototype must use keyword fallback');
+assert_same('', $config->endpoint, 'Prototype must not contact an embedding endpoint');
+assert_same(false, $config->uses_external_service(), 'Keyword fallback is local');
+
+$config = embedding_config_for([
+    'provider' => 'openai',
+    'embeddingprovider' => 'same_as_chat',
+]);
+assert_same('openai', $config->provider, 'OpenAI chat can use OpenAI embeddings');
+assert_same('https://api.openai.com/v1', $config->endpoint, 'OpenAI embeddings need the correct default endpoint');
+assert_same(true, $config->uses_external_service(), 'OpenAI endpoint is external');
+
+$config = embedding_config_for([
+    'provider' => 'ollama',
+    'embeddingprovider' => 'same_as_chat',
+]);
+assert_same('ollama', $config->provider, 'Ollama chat must use Ollama embeddings');
+assert_same('http://host.docker.internal:11434', $config->endpoint, 'Ollama needs the local default endpoint');
+assert_same(false, $config->uses_external_service(), 'Default Ollama endpoint is local');
+
+$config = embedding_config_for([
+    'provider' => 'gemini',
+    'embeddingprovider' => 'same_as_chat',
+]);
+assert_same('keyword', $config->provider, 'Unsupported chat embedding protocols must fall back to keywords');
+assert_same('', $config->endpoint, 'Unsupported providers must not fall through to Ollama');
+
+$config = embedding_config_for([
+    'provider' => 'prototype',
+    'embeddingprovider' => 'custom_http',
+    'embeddingendpoint' => 'https://embeddings.example.test/v1',
+]);
+assert_same('custom_http', $config->provider, 'Explicit custom embeddings must be preserved');
+assert_same('https://embeddings.example.test/v1', $config->endpoint, 'Custom embedding endpoint must be preserved');
+
+$config = embedding_config_for([
+    'provider' => 'openai',
+    'embeddingprovider' => 'openai',
+    'embeddingendpoint' => 'https://embeddings.example.test/v1/embeddings',
+]);
+$client = new embedding_client($config);
+$urlmethod = new ReflectionMethod($client, 'openai_url');
+$urlmethod->setAccessible(true);
+assert_same(
+    'https://embeddings.example.test/v1/embeddings',
+    $urlmethod->invoke($client),
+    'A full OpenAI embeddings endpoint must not gain a duplicate /v1 segment'
+);
+
+echo "embedding_config_test: OK\n";

--- a/tests/embedding_contract_test.php
+++ b/tests/embedding_contract_test.php
@@ -1,0 +1,30 @@
+<?php
+
+define('MOODLE_INTERNAL', true);
+
+function get_config($component, $name) {
+    return false;
+}
+
+require_once(__DIR__ . '/../plugins/aiskillnavigator/classes/service/embedding_service.php');
+
+use local_aiskillnavigator\service\embedding_service;
+
+$method = new ReflectionMethod(embedding_service::class, 'index_material');
+
+if ($method->getNumberOfRequiredParameters() !== 1) {
+    fwrite(STDERR, "index_material() must remain callable with a material ID only.\n");
+    exit(1);
+}
+
+if ($method->getNumberOfParameters() !== 4) {
+    fwrite(STDERR, "index_material() compatibility signature unexpectedly changed.\n");
+    exit(1);
+}
+
+if (!method_exists(embedding_service::class, 'index_material_by_id')) {
+    fwrite(STDERR, "index_material_by_id() compatibility entry point is missing.\n");
+    exit(1);
+}
+
+echo "embedding_contract_test: OK\n";

--- a/tests/php_bom_test.php
+++ b/tests/php_bom_test.php
@@ -1,0 +1,29 @@
+<?php
+
+$root = realpath(__DIR__ . '/../plugins');
+$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+$failed = [];
+
+foreach ($iterator as $file) {
+    if (!$file->isFile() || strtolower($file->getExtension()) !== 'php') {
+        continue;
+    }
+
+    $handle = fopen($file->getPathname(), 'rb');
+    $prefix = $handle ? fread($handle, 3) : '';
+
+    if ($handle) {
+        fclose($handle);
+    }
+
+    if ($prefix === "\xEF\xBB\xBF") {
+        $failed[] = substr($file->getPathname(), strlen(dirname($root)) + 1);
+    }
+}
+
+if ($failed) {
+    fwrite(STDERR, "UTF-8 BOM found in PHP files:\n- " . implode("\n- ", $failed) . "\n");
+    exit(1);
+}
+
+echo "php_bom_test: OK\n";

--- a/tests/rag_indexing_test.php
+++ b/tests/rag_indexing_test.php
@@ -1,0 +1,96 @@
+<?php
+
+define('MOODLE_INTERNAL', true);
+
+$testconfig = [
+    'provider' => 'prototype',
+    'embeddingprovider' => 'same_as_chat',
+];
+
+function get_config($component, $name) {
+    global $testconfig;
+
+    return array_key_exists($name, $testconfig) ? $testconfig[$name] : false;
+}
+
+class core_text {
+    public static function strlen(string $text): int {
+        return mb_strlen($text, 'UTF-8');
+    }
+
+    public static function substr(string $text, int $start, ?int $length = null): string {
+        return $length === null
+            ? mb_substr($text, $start, null, 'UTF-8')
+            : mb_substr($text, $start, $length, 'UTF-8');
+    }
+}
+
+class fake_moodle_database {
+    public stdClass $material;
+    public array $inserted = [];
+
+    public function __construct(stdClass $material) {
+        $this->material = $material;
+    }
+
+    public function get_record(string $table, array $conditions) {
+        if ($table === 'local_aiskillnav_material' && (int)$conditions['id'] === (int)$this->material->id) {
+            return clone $this->material;
+        }
+
+        return false;
+    }
+
+    public function delete_records(string $table, array $conditions): void {
+    }
+
+    public function insert_record(string $table, stdClass $record): int {
+        $this->inserted[] = clone $record;
+        return count($this->inserted);
+    }
+}
+
+require_once(__DIR__ . '/../plugins/aiskillnavigator/classes/service/embedding_service.php');
+
+use local_aiskillnavigator\service\embedding_service;
+
+$material = (object)[
+    'id' => 17,
+    'courseid' => 42,
+    'title' => 'Database fundamentals',
+    'content' => 'A relational database stores data in tables linked by keys.',
+    'externalaiallowed' => 0,
+    'aipolicy' => 'local_only',
+];
+
+$DB = new fake_moodle_database($material);
+$result = (new embedding_service())->index_material(17, 42);
+
+if (empty($result['success']) || (int)$result['chunks'] !== 1 || count($DB->inserted) !== 1) {
+    fwrite(STDERR, "RAG indexing by material ID failed.\n");
+    exit(1);
+}
+
+$embedding = json_decode((string)$DB->inserted[0]->embedding, true);
+
+if ($embedding !== []) {
+    fwrite(STDERR, "Prototype mode unexpectedly generated an external embedding.\n");
+    exit(1);
+}
+
+$testconfig = [
+    'provider' => 'openai',
+    'embeddingprovider' => 'same_as_chat',
+    'externalaiapproved' => '0',
+];
+$material->externalaiallowed = 1;
+$material->aipolicy = 'external_allowed';
+$DB = new fake_moodle_database($material);
+$result = (new embedding_service())->index_material(17, 42);
+
+if (empty($result['success']) || json_decode((string)$DB->inserted[0]->embedding, true) !== []) {
+    fwrite(STDERR, "External embeddings were not blocked by the global privacy gate.\n");
+    exit(1);
+}
+
+echo "rag_indexing_test: OK\n";

--- a/tests/xmldb_schema_test.php
+++ b/tests/xmldb_schema_test.php
@@ -1,0 +1,56 @@
+<?php
+
+$path = __DIR__ . '/../plugins/aiskillnavigator/db/install.xml';
+$xml = simplexml_load_file($path);
+
+if ($xml === false) {
+    fwrite(STDERR, "install.xml is not valid XML.\n");
+    exit(1);
+}
+
+$errors = [];
+$tablenames = [];
+
+foreach ($xml->TABLES->TABLE as $table) {
+    $tablename = (string)$table['NAME'];
+
+    if (isset($tablenames[$tablename])) {
+        $errors[] = "Duplicate table {$tablename}.";
+    }
+
+    $tablenames[$tablename] = true;
+    $fields = [];
+
+    foreach ($table->FIELDS->FIELD as $field) {
+        $fields[(string)$field['NAME']] = true;
+    }
+
+    foreach ($table->KEYS->KEY as $key) {
+        $keyname = (string)$key['NAME'];
+
+        foreach (preg_split('/\s*,\s*/', (string)$key['FIELDS']) as $fieldname) {
+            if ($fieldname !== '' && !isset($fields[$fieldname])) {
+                $errors[] = "{$tablename}.{$keyname} references missing field {$fieldname}.";
+            }
+        }
+    }
+
+    if (isset($table->INDEXES)) {
+        foreach ($table->INDEXES->INDEX as $index) {
+            $indexname = (string)$index['NAME'];
+
+            foreach (preg_split('/\s*,\s*/', (string)$index['FIELDS']) as $fieldname) {
+                if ($fieldname !== '' && !isset($fields[$fieldname])) {
+                    $errors[] = "{$tablename}.{$indexname} references missing field {$fieldname}.";
+                }
+            }
+        }
+    }
+}
+
+if ($errors) {
+    fwrite(STDERR, implode("\n", $errors) . "\n");
+    exit(1);
+}
+
+echo "xmldb_schema_test: OK\n";


### PR DESCRIPTION
## Summary

- restore automatic RAG indexing after course-resource synchronization
- enforce safe keyword fallback and global/per-material privacy gates for embeddings
- normalize OpenAI embedding endpoints and handle missing cURL gracefully
- reconcile XMLDB fresh-install and upgrade schemas
- clean stale synchronized resources and orphaned knowledge-graph data
- remove PHP BOM/mojibake regressions and fix CLI counters
- declare the block-to-local-plugin dependency
- add PHP 8.1–8.3 CI, JavaScript/XMLDB/YAML/BOM checks, regression tests, and release documentation

## Validation

- PHP 8.1 parser: 148 files
- `tests/embedding_config_test.php`
- `tests/embedding_contract_test.php`
- `tests/rag_indexing_test.php`
- `tests/xmldb_schema_test.php`
- `tests/php_bom_test.php`
- JavaScript syntax checks
- XMLDB and GitHub Actions YAML parsing
- `git diff --check`

All local checks passed. The PR remains a draft until the GitHub Actions matrix and a Moodle runtime smoke test are reviewed.