### PR TITLE
feat(simulator_finder): add reset button for search and filter contro…

### DIFF
--- a/plugins/aiskillnavigator/pages/simulator_finder.php
+++ b/plugins/aiskillnavigator/pages/simulator_finder.php
@@ -15,7 +15,13 @@ $action = optional_param('action', '', PARAM_ALPHA);
 $topic = optional_param('topic', '', PARAM_TEXT);
 $level = optional_param('level', 'medium', PARAM_ALPHA);
 $notes = optional_param('notes', '', PARAM_RAW_TRIMMED);
-
+//Reset
+if ($action === 'reset') {
+    $topic = '';
+    $level = 'medium';
+    $notes = '';
+    $action = '';
+}   
 $course = get_course($courseid);
 
 require_login($course);
@@ -570,6 +576,17 @@ echo html_writer::empty_tag('input', [
     'class' => 'btn btn-primary',
     'value' => 'Generate exercise and simulator',
 ]);
+
+echo ' ';
+
+echo html_writer::link(
+    new moodle_url('/local/aiskillnavigator/pages/simulator_finder.php', [
+        'courseid' => $courseid,
+        'action' => 'reset'
+    ]),
+    'Reset',
+    ['class' => 'btn btn-outline-secondary']
+);
 
 echo ' ';
 


### PR DESCRIPTION
…ls (#51 )

## What changed?
Added a reset button and handling logic to the simulator finder page. Clicking the Reset button clears the topic and notes fields and resets the difficulty level back to default ("medium").

Describe the change in a few sentences.

## Related issue

Closes #51 

## Validation

- [x ] I tested the changed behavior or documentation.
- [x ] PHP files pass php -l when applicable.
- [x ] JavaScript files pass node --check when applicable.
- [x ] No credentials, API keys, student data, or private course material are included.
- [x ] The Pull Request is focused on one issue.

## First contribution? One of the firsts.

Welcome. Small good first issue Pull Requests are prioritized for review.