### PR TITLE
docs: add privacy reminder for test data

### DIFF
--- a/BEGINNER_CONTRIBUTING.md
+++ b/BEGINNER_CONTRIBUTING.md
@@ -77,7 +77,7 @@ Open a Pull Request and include:
 - Do not add unrelated refactors.
 - Never commit API keys or credentials.
 - Never commit real student data.
-- Never upload private course material.
+- Never upload screenshots, fixtures, logs, or decks containing private course material.
 - Ask questions in the issue if anything is unclear.
 
 ## Maintainer goal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Also run the Moodle upgrade and the scenarios in `docs/manual-test-checklist.md`
 
 ## Security and privacy
 
-- Never commit API keys, credentials, student data, or exported course materials.
+- Never commit API keys, credentials, student data, or exported course materials. Screenshots, fixtures, logs, and decks must not contain this information.
 - External AI access must remain opt-in globally and per material.
 - Destructive Course Builder actions must remain disabled by default.
 - Use Moodle capabilities, `require_login()`, and sesskey validation for every protected action.


### PR DESCRIPTION
## What changed?

Updated the contribution documentation with privacy reminders for screenshots, fixtures, logs, and decks.

These reminders clarify that these materials must not contain sensitive student data, API keys, credentials, or private course material.

## Related issue

Closes #55

## Validation

* [x] I tested the changed behavior or documentation.
* [ ] PHP files pass php -l when applicable.
* [ ] JavaScript files pass node --check when applicable.
* [x] No credentials, API keys, student data, or private course material are included.
* [x] The Pull Request is focused on one issue.

## First contribution?

Welcome. Small good first issue Pull Requests are prioritized for review.
