### PR TITLE
Add contributor glossary for Moodle and AI terms Closes #132

### DIFF
--- a/docs/CONTRIBUTOR_GLOSSARY.md
+++ b/docs/CONTRIBUTOR_GLOSSARY.md
@@ -1,0 +1,43 @@
+# Contributor glossary
+
+This glossary explains common Moodle and AI terms used in AI Skill Navigator.
+
+## Block plugin
+
+A Moodle plugin that adds a small tool or information panel to a page, often in a course sidebar. AI Skill Navigator includes an optional block plugin that links users to its tools. [Moodle block plugins](https://moodledev.io/docs/5.3/apis/plugintypes/blocks)
+
+## Capability
+
+A named Moodle permission that controls whether a user can perform an action, such as viewing a feature or managing settings. Capabilities are assigned through roles. [Moodle Roles API](https://moodledev.io/docs/5.3/apis/subsystems/roles)
+
+## Chunk
+
+A small section of a larger document. RAG systems split course material into chunks so they can find the parts most relevant to a question. [OpenAI vector-store files](https://platform.openai.com/docs/api-reference/vector-stores-files)
+
+## Context
+
+The Moodle location where permissions apply, such as the whole site, a course, an activity, or a block. A user can have different permissions in different contexts. [Moodle Roles API](https://moodledev.io/docs/5.3/apis/subsystems/roles)
+
+## Embedding
+
+A numeric representation of text that helps software compare meaning. Embeddings help a RAG system find course-material chunks related to a question.
+
+## Language string
+
+A reusable piece of interface text, such as a button label or message, stored separately so Moodle can translate it into other languages. [Moodle plugin files](https://docs.moodle.org/dev/Plugin_files)
+
+## Local plugin
+
+A Moodle plugin used for site-wide or custom functionality that does not fit a more specific plugin type. AI Skill Navigator’s main plugin is a local plugin. [Moodle plugin types](https://moodledev.io/docs/5.3/apis/plugintypes)
+
+## Provider
+
+A service or implementation that supplies a feature to the plugin. For example, an AI provider can generate responses, and an embedding provider can prepare text for semantic search.
+
+## RAG
+
+Retrieval-Augmented Generation. A method where the system finds relevant course material first, then gives it to an AI model to help produce a more relevant answer.
+
+## Sesskey
+
+A Moodle security token included with requests that change data. It helps protect users from unwanted actions submitted through their browser. [Moodle plugin contribution checklist](https://docs.moodle.org/dev/Plugin_contribution_checklist)


### PR DESCRIPTION
This document provides definitions for key terms related to Moodle and AI used in the AI Skill Navigator.

## What changed?

Added docs/CONTRIBUTOR_GLOSSARY.md with 10 beginner-friendly definitions for Moodle and AI/RAG terms used in AI Skill Navigator.

The glossary includes definitions for local plugins, block plugins, capabilities, contexts, sesskeys, language strings, RAG, chunks, providers, and embeddings, along with authoritative reference links.

## Related issue

Closes #132 

## Validation

- [* ] I tested the changed behavior or documentation.
- [ ] PHP files pass php -l when applicable.
- [ ] JavaScript files pass node --check when applicable.
- [* ] No credentials, API keys, student data, or private course material are included.
- [ *] The Pull Request is focused on one issue.

## First contribution?

Welcome. Small good first issue Pull Requests are prioritized for review.

<!-- MICRO-PR-START -->

### Micro-contribution checklist

If this PR closes a `micro-contribution` issue:

- [ ] I changed only the requested tiny file.
- [ ] I replaced all placeholders.
- [ ] The content is original and contains no private data or secrets.
- [ ] I linked the issue with `Closes #...`.

<!-- MICRO-PR-END -->


## Support the project

If you enjoyed contributing or find AI Skill Navigator useful, consider starring the repository.
A star is appreciated, but it is never required for review or merge.
