### PR TITLE
docs: add 2-minute first-contribution landing

### DIFF
--- a/BEGINNER_CONTRIBUTING.md
+++ b/BEGINNER_CONTRIBUTING.md
@@ -1,18 +1,19 @@
-﻿# Beginner Contributing Guide
+# Beginner Contributing Guide
 
 <!-- MICRO-GUIDE-START -->
 
-## Fastest first contribution: 2–5 minutes
+## Fastest first contribution: about 2 minutes
 
-For the smallest browser-only contribution:
+For the shortest browser-only path, start with **[FIRST-CONTRIBUTION.md](FIRST-CONTRIBUTION.md)**.
 
-1. Open the issues labelled `micro-contribution`.
-2. Pick one unassigned task.
-3. Fork the repository.
-4. Create the exact JSON file requested by the issue using GitHub's web interface.
-5. Replace the placeholder with your own concise content.
-6. Commit in your fork.
-7. Open a Pull Request with `Closes #ISSUE_NUMBER`.
+In short:
+
+1. Open an unassigned issue labelled `micro-contribution`.
+2. Fork the repository.
+3. Create the exact JSON file requested by the issue using GitHub's web interface.
+4. Replace the placeholder with your own concise content.
+5. Commit in your fork.
+6. Open a Pull Request with `Closes #ISSUE_NUMBER`, using the issue number you selected.
 
 No Moodle installation, PHP setup or local clone is needed for these tasks.
 
@@ -28,26 +29,24 @@ This guide is designed for people making their first open-source contribution. Y
 
 ## Start here
 
-1. Star our repo.
-2. Fork the repository.
-3. Pick an open issue labelled good first issue.
-4. Comment on the issue if you want to work on it.
-5. Make the requested change.
-6. Open a Pull Request that links the issue.
+1. Pick an open issue labelled `good first issue` or `micro-contribution`.
+2. Comment on the issue if you want to work on it.
+3. Fork the repository.
+4. Make the requested change.
+5. Open a Pull Request that links the issue.
 
-The maintainer workflow does not automatically verify stars. Pull Requests are reviewed on the submitted change.
+The maintainer workflow does not verify stars. Pull Requests are reviewed on the submitted change.
 
 ## Browser-only contribution
 
-Some documentation, translation, and Flashcards content tasks can be completed from GitHub without installing Moodle.
+Some documentation, glossary, prompt, flashcard and use-case tasks can be completed entirely on GitHub without installing Moodle.
 
-1. Open the file linked from the issue.
-2. Click the edit button.
-3. GitHub can create a fork for you.
-4. Make the requested change.
-5. Commit it to your fork.
-6. Open a Pull Request.
-7. Put Closes #ISSUE_NUMBER in the PR description.
+1. Open the exact path specified in the issue.
+2. Use GitHub's web interface to create or edit the requested file in your fork.
+3. Make only the requested change.
+4. Commit it to your fork.
+5. Open a Pull Request.
+6. Put `Closes #ISSUE_NUMBER` in the PR description, using the issue number you selected.
 
 ## Local contribution
 

--- a/FIRST-CONTRIBUTION.md
+++ b/FIRST-CONTRIBUTION.md
@@ -1,0 +1,67 @@
+# Make your first open-source PR in about 2 minutes
+
+**No Moodle installation. No local clone. No development setup.**
+
+AI Skill Navigator has tiny browser-only contributions designed for first-time open-source contributors. Most of them require creating **one small JSON file** directly on GitHub.
+
+## Start here
+
+### 1. Pick one tiny unassigned issue
+
+[Browse open micro-contributions →](https://github.com/Berserk-hub150/moodle-ai-skill-navigator/issues?q=is%3Aissue%20is%3Aopen%20label%3Amicro-contribution%20no%3Aassignee)
+
+Look for a task you can complete comfortably. Typical contributions include:
+
+- one AI learning prompt;
+- one beginner-friendly glossary definition;
+- one flashcard;
+- one realistic Moodle/AI learning use case;
+- one short educational tip.
+
+### 2. Create the requested file in your browser
+
+Open the exact path shown in the issue, choose **Add file → Create new file**, and paste the JSON skeleton from the issue.
+
+Replace every `REPLACE_ME` value with your own concise, original content.
+
+You do **not** need to install Moodle, PHP, Node.js, Docker, or an AI model for these tasks.
+
+### 3. Open the Pull Request
+
+Commit the file to your fork and open a Pull Request back to this repository.
+
+In the PR description, add:
+
+```text
+Closes #ISSUE_NUMBER
+```
+
+Use the number of the issue you actually selected.
+
+## What happens next?
+
+The repository automatically validates micro-contribution JSON files. Small first-time-contributor Pull Requests are prioritized for review when possible.
+
+A valid contribution should be:
+
+- one focused change for the selected issue;
+- valid JSON;
+- original and useful;
+- free of API keys, credentials, private student data, and private course material;
+- free of copied copyrighted passages.
+
+## Already comfortable with beginner-friendly open source?
+
+If you have contributed to projects such as **Kana Dojo** or other repositories built around small `good first issue` tasks, the workflow should feel familiar:
+
+**Pick an issue → Fork → Create one tiny file → Pull Request → Contributor**
+
+This project is independent from Kana Dojo; the reference simply describes a similar beginner-friendly contribution workflow.
+
+## Want a larger task instead?
+
+Browse all [good first issues](https://github.com/Berserk-hub150/moodle-ai-skill-navigator/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or read the full [Beginner Contributing Guide](BEGINNER_CONTRIBUTING.md).
+
+---
+
+If the project is useful to you, a GitHub star helps other Moodle and open-source developers discover it. **A star is appreciated, never required for review or merge.**


### PR DESCRIPTION
## What this changes

- adds `FIRST-CONTRIBUTION.md` as a focused browser-only onboarding landing;
- points the beginner guide to the shortest contribution path;
- makes stars explicitly optional rather than part of the required workflow;
- reminds contributors to use the issue number they actually selected in `Closes #...`;
- includes a non-affiliation note for contributors familiar with Kana Dojo-style beginner tasks.

## Why

The repository already has strong micro-contribution infrastructure. This makes the entry path easier to share directly with prospective first-time contributors and reduces avoidable onboarding mistakes.