### PR TITLE
docs: update Moodle plugin ranking to #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@
 
 <p align="center">
   <img
-    src="https://img.shields.io/badge/%236-MOST--STARRED%20MOODLE%20PLUGIN-6C5CE7?style=for-the-badge"
-    alt="#6 most-starred Moodle plugin repository on GitHub"
+    src="https://img.shields.io/badge/%235-MOST--STARRED%20MOODLE%20PLUGIN-6C5CE7?style=for-the-badge"
+    alt="#5 most-starred Moodle plugin repository on GitHub"
     height="36"
   >
 </p>
 
 <p align="center">
-  <strong>🏆 #6 most-starred Moodle plugin repository on GitHub</strong>
+  <strong>🏆 #5 most-starred Moodle plugin repository on GitHub</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- update the ranking badge from `#6` to `#5`
- update the badge alternative text
- update the visible ranking statement

AI Skill Navigator now has 166 stars and has overtaken STACK (164 stars) as of August 27, 2026.