### PR TITLE
Add key terms review prompt

### DIFF
--- a/community/micro-contributions/prompts/key-terms-review.json
+++ b/community/micro-contributions/prompts/key-terms-review.json
@@ -1,0 +1,2 @@
+
+{"name":"Key terms review","prompt":"Identify the key terms from this course section and quiz me on their meanings one at a time. Wait for my answer before giving me the next term."}


### PR DESCRIPTION
## What changed

Added a beginner-friendly key terms review prompt that asks the tutor to identify key terms from a course section and quiz the learner one at a time.

## Related issue

Closes #214 

## Validation

- [x] I tested the changed documentation.
- [x] No credentials, API keys, student data, or private course material are included.
- [x] The Pull Request is focused on one issue.

## Micro-contribution checklist

- [x] I changed only the requested tiny file.
- [x] I replaced all placeholders.
- [x] The content is original and contains no private data or secrets.
- [x] I linked the issue with `Closes #...`.