### PR TITLE
fix: improve mind map accessible names

### DIFF
--- a/plugins/aiskillnavigator/pages/mindmapgenerator.php
+++ b/plugins/aiskillnavigator/pages/mindmapgenerator.php
@@ -1107,7 +1107,7 @@ echo html_writer::end_div();
     'aria-label' => 'Select mind map node: ' . s($node['title']),
 ]);
     }
-    }
+    
 
     echo html_writer::end_div();
 

--- a/plugins/aiskillnavigator/pages/mindmapgenerator.php
+++ b/plugins/aiskillnavigator/pages/mindmapgenerator.php
@@ -1003,12 +1003,23 @@ if ($map !== null) {
 
     // phpcs:ignore moodle.Files.LineLength
     echo html_writer::tag('p', 'Drag the canvas, drag nodes, use mouse wheel to zoom, or use the controls below.', ['class' => 'text-muted']);
-
-    echo html_writer::start_div('aisn-mm-controls');
-    echo html_writer::tag('button', 'Zoom -', ['type' => 'button', 'id' => 'aisn-mm-zoom-out']);
-    echo html_writer::tag('button', 'Reset view', ['type' => 'button', 'id' => 'aisn-mm-reset']);
-    echo html_writer::tag('button', 'Zoom +', ['type' => 'button', 'id' => 'aisn-mm-zoom-in']);
-    echo html_writer::end_div();
+echo html_writer::start_div('aisn-mm-controls');
+echo html_writer::tag('button', 'Zoom -', [
+    'type' => 'button',
+    'id' => 'aisn-mm-zoom-out',
+    'aria-label' => 'Zoom out',
+]);
+echo html_writer::tag('button', 'Reset view', [
+    'type' => 'button',
+    'id' => 'aisn-mm-reset',
+    'aria-label' => 'Reset mind map view',
+]);
+echo html_writer::tag('button', 'Zoom +', [
+    'type' => 'button',
+    'id' => 'aisn-mm-zoom-in',
+    'aria-label' => 'Zoom in',
+]);
+echo html_writer::end_div();
 
     echo html_writer::end_div();
 
@@ -1090,10 +1101,12 @@ if ($map !== null) {
         $class = 'aisn-mm-node ' . s($node['type']);
 
         echo html_writer::tag('button', s($node['title']), [
-            'type' => 'button',
-            'class' => $class,
-            'data-id' => s($node['id']),
-        ]);
+    'type' => 'button',
+    'class' => $class,
+    'data-id' => s($node['id']),
+    'aria-label' => 'Select mind map node: ' . s($node['title']),
+]);
+    }
     }
 
     echo html_writer::end_div();


### PR DESCRIPTION
Added accessibility features to mind map controls and node buttons.

## What changed?

Improves accessibility of the Mind Map Generator by adding meaningful accessible names to the zoom, reset, and mind-map node controls.


## Related issue

Closes #122

## Validation

- [ ] I tested the changed behavior or documentation.
- [ ] PHP files pass php -l when applicable.
- [ ] JavaScript files pass node --check when applicable.
- [ ] No credentials, API keys, student data, or private course material are included.
- [ ] The Pull Request is focused on one issue.

## First contribution?

Welcome. Small good first issue Pull Requests are prioritized for review.

<!-- MICRO-PR-START -->

### Micro-contribution checklist

If this PR closes a `micro-contribution` issue:

- [ ] I changed only the requested tiny file.
- [ ] I replaced all placeholders.
- [ ] The content is original and contains no private data or secrets.
- [ ] I linked the issue with `Closes #...`.

<!-- MICRO-PR-END -->


## Support the project

If you enjoyed contributing or find AI Skill Navigator useful, consider starring the repository.
A star is appreciated, but it is never required for review or merge.
