### PR TITLE
feat: add Flashcards entry to student tools page

### DIFF
--- a/plugins/aiskillnavigator/pages/index.php
+++ b/plugins/aiskillnavigator/pages/index.php
@@ -334,6 +334,15 @@ if ($isstudent) {
         'btn btn-outline-primary',
         'Map'
     );
+    echo local_aisn_index_card(
+        'Flashcards',
+        'Review course topics with quick flip-style flashcards.',
+        '/local/aiskillnavigator/pages/flashcards.php',
+        $courseid,
+        'Open Flashcards',
+        'btn btn-outline-info',
+        'Flashcards'
+    );
     echo html_writer::end_div();
 }
 


### PR DESCRIPTION
## What changed?

Add a Flashcards tool card to the student tools section of the AI Skill Navigator index page, following the existing card pattern. Links to /local/aiskillnavigator/pages/flashcards.php (page itself out of scope for this change).

## Related issue

Closes #102

## Validation

- [x] I tested the changed behavior or documentation.
- [x] PHP files pass php -l when applicable.
- [x] JavaScript files pass node --check when applicable.
- [x] No credentials, API keys, student data, or private course material are included.
- [x] The Pull Request is focused on one issue.

<img width="1375" height="598" alt="image" src="https://github.com/user-attachments/assets/f45ede6e-54d2-49a5-a9c5-e2426e6550f6" />

## First contribution?

Welcome. Small good first issue Pull Requests are prioritized for review.

<!-- MICRO-PR-START -->

### Micro-contribution checklist

If this PR closes a `micro-contribution` issue:

- [ ] I changed only the requested tiny file.
- [ ] I replaced all placeholders.
- [ ] The content is original and contains no private data or secrets.
- [ ] I linked the issue with `Closes #...`.

<!-- MICRO-PR-END -->


## Support the project

If you enjoyed contributing or find AI Skill Navigator useful, consider starring the repository.
A star is appreciated, but it is never required for review or merge.